### PR TITLE
Speed up project cleanup by resetting Qdrant collections

### DIFF
--- a/src/cornerstone/app.py
+++ b/src/cornerstone/app.py
@@ -1794,10 +1794,8 @@ def create_app(
         settings: Settings = Depends(get_settings_dependency),
     ) -> RedirectResponse:
         project = _resolve_project(project_store, project_id)
-        documents = project_store.list_documents(project.id)
         cleared = store_manager.purge_project(project.id)
-        for doc in documents:
-            fts_index.delete_document(project.id, doc.id)
+        fts_index.delete_project(project.id)
         project_store.clear_documents(project.id)
         manifest_path = Path(settings.data_dir).resolve() / "manifests" / f"{project.id}.json"
         if manifest_path.exists():

--- a/src/cornerstone/fts.py
+++ b/src/cornerstone/fts.py
@@ -91,6 +91,15 @@ class FTSIndex:
                 (project_id, doc_id),
             )
 
+    def delete_project(self, project_id: str) -> None:
+        """Remove all indexed chunks for the given project."""
+
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM chunk_search WHERE project_id = ?",
+                (project_id,),
+            )
+
     def search(self, project_id: str, query: str, *, limit: int = 10) -> List[dict[str, str]]:
         query = (query or "").strip()
         if not query:

--- a/src/cornerstone/ingestion.py
+++ b/src/cornerstone/ingestion.py
@@ -329,11 +329,13 @@ class ProjectVectorStoreManager:
         """Remove all vectors associated with a project."""
 
         store = self.get_store(project_id)
-        flt = models.Filter(
-            must=[models.FieldCondition(key="project_id", match=models.MatchValue(value=project_id))]
-        )
-        result = store.delete_by_filter(flt)
-        return result.status == models.UpdateStatus.COMPLETED
+        try:
+            store.ensure_collection(force_recreate=True)
+            store.ensure_payload_indexes()
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("vector_store.purge_failed project=%s", project_id)
+            return False
+        return True
 
     def iter_project_payloads(self, project_id: str, *, batch_size: int = 256):
         """Yield payload dictionaries for all vectors stored for a project."""

--- a/tests/test_document_ingestion.py
+++ b/tests/test_document_ingestion.py
@@ -472,6 +472,7 @@ def test_cleanup_endpoint_purges_project_vectors():
     assert documents
     store = state.store_manager.get_store(project.id)
     assert store.count() > 0
+    assert state.fts_index.search(project.id, "Troubleshooting")
 
     response = client.post(
         "/knowledge/cleanup",
@@ -481,6 +482,7 @@ def test_cleanup_endpoint_purges_project_vectors():
     assert response.status_code == 303
     assert project_store.list_documents(project.id) == []
     assert store.count() == 0
+    assert state.fts_index.search(project.id, "Troubleshooting") == []
 
 
 def test_ingested_chunks_include_metadata_summary_and_language():


### PR DESCRIPTION
## Summary
- drop and recreate Qdrant collections during `ProjectVectorStoreManager.purge_project` so vector cleanup scales with project size
- add a bulk `FTSIndex.delete_project` helper and wire it into the knowledge cleanup endpoint
- extend the cleanup integration test to verify FTS entries are removed along with vectors

## Testing
- pytest tests/test_document_ingestion.py::test_cleanup_endpoint_purges_project_vectors -q

------
https://chatgpt.com/codex/tasks/task_e_68f8d69d621c832cadce118079800ee0