### PR TITLE
Improve project cleanup speed

### DIFF
--- a/src/cornerstone/app.py
+++ b/src/cornerstone/app.py
@@ -1794,10 +1794,8 @@ def create_app(
         settings: Settings = Depends(get_settings_dependency),
     ) -> RedirectResponse:
         project = _resolve_project(project_store, project_id)
-        documents = project_store.list_documents(project.id)
         cleared = store_manager.purge_project(project.id)
-        for doc in documents:
-            fts_index.delete_document(project.id, doc.id)
+        fts_index.delete_project(project.id)
         project_store.clear_documents(project.id)
         manifest_path = Path(settings.data_dir).resolve() / "manifests" / f"{project.id}.json"
         if manifest_path.exists():

--- a/src/cornerstone/fts.py
+++ b/src/cornerstone/fts.py
@@ -91,6 +91,15 @@ class FTSIndex:
                 (project_id, doc_id),
             )
 
+    def delete_project(self, project_id: str) -> None:
+        """Remove all indexed chunks for the provided project."""
+
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM chunk_search WHERE project_id = ?",
+                (project_id,),
+            )
+
     def search(self, project_id: str, query: str, *, limit: int = 10) -> List[dict[str, str]]:
         query = (query or "").strip()
         if not query:

--- a/src/cornerstone/ingestion.py
+++ b/src/cornerstone/ingestion.py
@@ -329,11 +329,9 @@ class ProjectVectorStoreManager:
         """Remove all vectors associated with a project."""
 
         store = self.get_store(project_id)
-        flt = models.Filter(
-            must=[models.FieldCondition(key="project_id", match=models.MatchValue(value=project_id))]
-        )
-        result = store.delete_by_filter(flt)
-        return result.status == models.UpdateStatus.COMPLETED
+        store.ensure_collection(force_recreate=True)
+        store.ensure_payload_indexes()
+        return True
 
     def iter_project_payloads(self, project_id: str, *, batch_size: int = 256):
         """Yield payload dictionaries for all vectors stored for a project."""

--- a/tests/test_document_ingestion.py
+++ b/tests/test_document_ingestion.py
@@ -472,6 +472,8 @@ def test_cleanup_endpoint_purges_project_vectors():
     assert documents
     store = state.store_manager.get_store(project.id)
     assert store.count() > 0
+    fts_index: FTSIndex = state.fts_index
+    assert fts_index.search(project.id, "Troubleshooting"), "Expected FTS results before cleanup"
 
     response = client.post(
         "/knowledge/cleanup",
@@ -481,6 +483,7 @@ def test_cleanup_endpoint_purges_project_vectors():
     assert response.status_code == 303
     assert project_store.list_documents(project.id) == []
     assert store.count() == 0
+    assert fts_index.search(project.id, "Troubleshooting") == []
 
 
 def test_ingested_chunks_include_metadata_summary_and_language():

--- a/tests/test_ingestion_manager.py
+++ b/tests/test_ingestion_manager.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from qdrant_client import models
+
+from cornerstone.ingestion import ProjectVectorStoreManager
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.collections: set[str] = set()
+        self.calls: list[tuple] = []
+
+    def collection_exists(self, name: str) -> bool:
+        self.calls.append(("exists", name))
+        return name in self.collections
+
+    def create_collection(self, **kwargs):
+        name = kwargs["collection_name"]
+        self.collections.add(name)
+        self.calls.append(("create", name))
+
+    def delete_collection(self, name: str) -> None:
+        self.calls.append(("delete", name))
+        self.collections.discard(name)
+
+    def create_payload_index(self, collection_name: str, field_name: str, field_schema) -> None:
+        self.calls.append(("index", collection_name, field_name))
+
+    def get_collection(self, name: str) -> SimpleNamespace:
+        # Provide minimal info if queried; size value is irrelevant for this test.
+        self.calls.append(("get", name))
+        return SimpleNamespace(config=SimpleNamespace(params=SimpleNamespace(vectors=SimpleNamespace(size=3))))
+
+
+def test_purge_project_recreates_collection_and_indexes() -> None:
+    client = FakeClient()
+    manager = ProjectVectorStoreManager(
+        client_factory=lambda: client,
+        vector_size=3,
+        distance=models.Distance.COSINE,
+        collection_name_fn=lambda project_id: f"collection-{project_id}",
+    )
+
+    manager.get_store("alpha")
+    client.calls.clear()
+
+    assert manager.purge_project("alpha") is True
+
+    assert ("exists", "collection-alpha") in client.calls
+    assert ("delete", "collection-alpha") in client.calls
+    assert ("create", "collection-alpha") in client.calls
+
+    index_calls = [call for call in client.calls if call[0] == "index"]
+    assert index_calls, "Expected payload indexes to be recreated after purge"


### PR DESCRIPTION
## Summary
- recreate per-project Qdrant collections during cleanup and cache payload index setup to avoid slow filtered deletions
- add a bulk FTS deletion helper and wire the cleanup endpoint to drop all project rows in one statement
- cover the new purge flow with targeted tests and ensure the UI cleanup test verifies FTS removal

## Testing
- pytest tests/test_ingestion_manager.py tests/test_document_ingestion.py::test_cleanup_endpoint_purges_project_vectors tests/test_qdrant_store.py::test_ensure_payload_indexes_creates_indexes


------
https://chatgpt.com/codex/tasks/task_e_68f8d69d621c832cadce118079800ee0