### PR TITLE
fix(ci): harden browser evidence startup

### DIFF
--- a/.github/workflows/product-ui-evidence.yml
+++ b/.github/workflows/product-ui-evidence.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Capture current-revision browser evidence
         run: |
+          set -o pipefail
           python scripts/capture_vs4_h01_ui_recovery_screenshots.py \
             --output-dir "$RUNNER_TEMP/cornerstone-product-ui-capture" \
             --state-dir "$RUNNER_TEMP/cornerstone-product-ui-state" \

--- a/scripts/capture_vs4_h01_ui_recovery_screenshots.py
+++ b/scripts/capture_vs4_h01_ui_recovery_screenshots.py
@@ -53,6 +53,7 @@ PRODUCT_RUNTIME_SOURCES = (
 UI_ASSET_ROOT = ROOT / "packages/cornerstone_cli/ui"
 REFERENCE_IMAGE_ROOT = ROOT / "docs/design/reference-images"
 DESIGN_TOKEN_PATH = ROOT / "docs/design/tokens/cornerstone_design_tokens_v0_3.json"
+DEVTOOLS_READY_TIMEOUT_SECONDS = 20.0
 
 FORBIDDEN_PRODUCT_RE = re.compile(
     r"local_scenario_ready=|vs0_runtime_ready=|production_release_ready=|real_external_http_calls=|"
@@ -689,11 +690,14 @@ def capture_page(
     try:
         process = _launch_cdp_chrome(chrome, profile_dir, debug_port, window_size)
         version = None
-        for _ in range(80):
+        devtools_deadline = time.monotonic() + DEVTOOLS_READY_TIMEOUT_SECONDS
+        while time.monotonic() < devtools_deadline:
             try:
                 version = _json_urlopen(f"http://127.0.0.1:{debug_port}/json/version")
                 break
             except OSError:
+                if process.poll() is not None:
+                    raise RuntimeError(f"devtools_process_exited:{process.returncode}")
                 time.sleep(0.1)
         if version is None:
             raise TimeoutError("devtools_version")


### PR DESCRIPTION
## What changed

- Extend the bounded Chrome DevTools readiness window from 8 to 20 seconds for cold Ubuntu runner startup.
- Fail immediately with an explicit process-exit reason if Chrome terminates before exposing DevTools.
- Enable `pipefail` so `tee` cannot mask a failed capture command.

## Why

The post-merge `main` run for PR #25 passed compile, design, 52 UI tests, and CLI parity, then one cold-start Chrome instance missed the 8-second DevTools window. Capture correctly marked the page failed, but the shell pipeline reported the capture step green because `tee` returned zero. Persisted validation caught the failure. This hardens startup while preserving fail-closed evidence behavior.

## Verification

- Workflow YAML parse — PASS
- Python compile — PASS
- `git diff --check` — PASS
- Fresh local browser evidence — 47/47 PASS
- Persisted capture manifest validation — PASS