### PR TITLE
Close the pre-VS5 trust foundation

### DIFF
--- a/.github/workflows/product-ui-evidence.yml
+++ b/.github/workflows/product-ui-evidence.yml
@@ -4,47 +4,57 @@ on:
   pull_request:
     paths:
       - ".github/workflows/product-ui-evidence.yml"
-      - "docs/design/reference-images/**"
-      - "docs/design/tokens/**"
-      - "packages/cornerstone_cli/__init__.py"
-      - "packages/cornerstone_cli/acceptance.py"
-      - "packages/cornerstone_cli/artifacts.py"
-      - "packages/cornerstone_cli/briefing.py"
-      - "packages/cornerstone_cli/main.py"
-      - "packages/cornerstone_cli/product_access.py"
-      - "packages/cornerstone_cli/product_runtime.py"
-      - "packages/cornerstone_cli/product_ui.py"
-      - "packages/cornerstone_cli/product_visibility.py"
-      - "packages/cornerstone_cli/runtime.py"
-      - "packages/cornerstone_cli/ui/**"
-      - "packages/cornerstone_cli/validators.py"
+      - "Makefile"
+      - "README.md"
+      - "AGENTS.md"
+      - "cornerstone"
+      - "docs/adr/**"
+      - "docs/agent/**"
+      - "docs/design/**"
+      - "docs/handoff/**"
+      - "docs/scenario-contracts/**"
+      - "docs/sot/**"
+      - "docs/verification-reports/VS0_SCAFFOLD_READINESS_REPORT_V0.md"
+      - "docs/verification-reports/template.md"
+      - "fixtures/vs0/**"
+      - "packages/cornerstone_cli/**"
+      - "run.sh"
       - "scripts/capture_vs4_h01_ui_recovery_screenshots.py"
+      - "scripts/verify_cli_native_first_docs.sh"
       - "scripts/verify_design_system_docs.sh"
-      - "tests/scenario/test_product_ui_routes.py"
-      - "tests/scenario/test_scaffold_cli.py"
+      - "scripts/verify_local_verification_plane_docs.sh"
+      - "scripts/verify_scenario_matrix.py"
+      - "scripts/verify_sot_docs.sh"
+      - "scripts/verify_vs0_scaffold_readiness_docs.sh"
+      - "tests/scenario/**"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/product-ui-evidence.yml"
-      - "docs/design/reference-images/**"
-      - "docs/design/tokens/**"
-      - "packages/cornerstone_cli/__init__.py"
-      - "packages/cornerstone_cli/acceptance.py"
-      - "packages/cornerstone_cli/artifacts.py"
-      - "packages/cornerstone_cli/briefing.py"
-      - "packages/cornerstone_cli/main.py"
-      - "packages/cornerstone_cli/product_access.py"
-      - "packages/cornerstone_cli/product_runtime.py"
-      - "packages/cornerstone_cli/product_ui.py"
-      - "packages/cornerstone_cli/product_visibility.py"
-      - "packages/cornerstone_cli/runtime.py"
-      - "packages/cornerstone_cli/ui/**"
-      - "packages/cornerstone_cli/validators.py"
+      - "Makefile"
+      - "README.md"
+      - "AGENTS.md"
+      - "cornerstone"
+      - "docs/adr/**"
+      - "docs/agent/**"
+      - "docs/design/**"
+      - "docs/handoff/**"
+      - "docs/scenario-contracts/**"
+      - "docs/sot/**"
+      - "docs/verification-reports/VS0_SCAFFOLD_READINESS_REPORT_V0.md"
+      - "docs/verification-reports/template.md"
+      - "fixtures/vs0/**"
+      - "packages/cornerstone_cli/**"
+      - "run.sh"
       - "scripts/capture_vs4_h01_ui_recovery_screenshots.py"
+      - "scripts/verify_cli_native_first_docs.sh"
       - "scripts/verify_design_system_docs.sh"
-      - "tests/scenario/test_product_ui_routes.py"
-      - "tests/scenario/test_scaffold_cli.py"
+      - "scripts/verify_local_verification_plane_docs.sh"
+      - "scripts/verify_scenario_matrix.py"
+      - "scripts/verify_sot_docs.sh"
+      - "scripts/verify_vs0_scaffold_readiness_docs.sh"
+      - "tests/scenario/**"
   workflow_dispatch:
 
 permissions:
@@ -58,6 +68,8 @@ jobs:
   verify-product-ui:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PYTHONPATH: packages
 
     steps:
       - name: Check out source
@@ -68,37 +80,50 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Compile the product UI slice
+      - name: Compile the CornerStone Python package
         run: |
-          python -m py_compile \
-            packages/cornerstone_cli/__init__.py \
-            packages/cornerstone_cli/acceptance.py \
-            packages/cornerstone_cli/artifacts.py \
-            packages/cornerstone_cli/briefing.py \
-            packages/cornerstone_cli/main.py \
-            packages/cornerstone_cli/product_access.py \
-            packages/cornerstone_cli/product_runtime.py \
-            packages/cornerstone_cli/product_ui.py \
-            packages/cornerstone_cli/product_visibility.py \
-            packages/cornerstone_cli/runtime.py \
-            packages/cornerstone_cli/ui/__init__.py \
-            packages/cornerstone_cli/ui/icons.py \
-            packages/cornerstone_cli/ui/language.py \
-            packages/cornerstone_cli/ui/styles.py \
-            scripts/capture_vs4_h01_ui_recovery_screenshots.py
+          python -m compileall -q packages/cornerstone_cli
+          python -m py_compile scripts/capture_vs4_h01_ui_recovery_screenshots.py
 
-      - name: Verify design-system inputs
-        run: scripts/verify_design_system_docs.sh
+      - name: Verify product authority and scenario documents
+        run: |
+          scripts/verify_sot_docs.sh
+          python scripts/verify_scenario_matrix.py
 
-      - name: Run focused product UI tests
+      - name: Run product UI route regressions
         run: python -m unittest tests.scenario.test_product_ui_routes
 
-      - name: Run focused CLI parity tests
+      - name: Run deterministic active-spine CLI regressions
         run: |
           python -m unittest \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_runtime_model_config_is_immutable_and_loopback_only \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_citation_chunk_ids_reject_path_traversal_before_disk_access \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_statement_source_anchor_scopes_negation_and_numeric_tokens \
             tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_briefing_application_applies_one_config_to_brief_and_ask \
             tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_artifact_ingest_show_and_audit_verify \
-            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_search_query_and_evidence_bundle
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_audit_verify_rejects_tampering \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_prompt_injection_ingest_records_policy_denial \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_search_query_and_evidence_bundle \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_claim_create_from_brief_preserves_cli_lineage \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_empty_evidence_bundle_cannot_create_evidence_backed_claim \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs0_universal_core_verify \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs0_claim_evidence_verify \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs0_briefing_verify \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs0_detail_surfaces_verify \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs0_conversation_onboarding_verify \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_runtime_acceptance_quickstart_executes_only_the_active_structural_spine
+
+      - name: Run deterministic VS5 citation-integrity regressions
+        run: |
+          python -m unittest \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs5_brief_rejects_a_valid_plus_fabricated_model_citation \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs5_brief_keeps_real_but_unrelated_citation_in_draft \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs5_brief_rejects_valid_same_scope_citation_outside_current_retrieval \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs5_ask_rejects_a_valid_plus_fabricated_model_citation \
+            tests.scenario.test_scaffold_cli.ScaffoldCliTests.test_vs5_ask_rejects_valid_same_scope_citation_outside_current_retrieval
+
+      - name: Run deterministic trust-foundation regressions
+        run: python -m unittest tests.scenario.test_trust_foundation_runtime
 
       - name: Capture current-revision browser evidence
         run: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CornerStone
 
-**Date:** 2026-07-04
+**Date:** 2026-07-11
 **Owner:** JiYong / Tars
-**Status:** Product-value-first reset (see `docs/adr/ADR-0007-product-value-first-reset.md`). Local structural substrate is real and verified; the intelligence layer is the active build; next proof point is external.
+**Status:** Product-value-first reset (see `docs/adr/ADR-0007-product-value-first-reset.md`). The local structural substrate and model-backed application path exist; real-model quality and external product value remain unverified.
 **Canonical spelling:** Use **CornerStone** for product/project text.
 
 ## What CornerStone Is Becoming
@@ -21,7 +21,7 @@ Everything on the spine is active. Everything off the spine is dormant until use
 
 ## Current State, Honestly
 
-Reviewed and live-tested 2026-07-04 (`docs/adr/ADR-0007-product-value-first-reset.md`).
+Repository boundary reviewed 2026-07-11. The product direction remains governed by `docs/adr/ADR-0007-product-value-first-reset.md`.
 
 **Verified working (Plane 1 — structural):**
 
@@ -29,12 +29,16 @@ Reviewed and live-tested 2026-07-04 (`docs/adr/ADR-0007-product-value-first-rese
 - Hash-chained, tamper-evident audit ledger (`cornerstone audit verify`).
 - Evidence bundles linking briefs/claims to source artifacts; owner/namespace scoping on every record.
 - Local runtime with a calm web UI, full CLI parity (`--json`, evidence refs, audit refs), and real Chrome-CDP browser proofs.
-- Deterministic scenario verification harness across VS0–VS4 (27/28 VS4 rows structurally green; `VS4-H01` owner review still open).
+- Deterministic scenario verification harness across VS0–VS4 (27/28 VS4 rows structurally green; `VS4-H01` owner review was rejected and remains open).
 
-**Not yet real (the active build):**
+**Implemented, but not yet value-verified (the active build):**
 
-- **There is no model integration yet.** Briefs are currently extractive snippets of the user's own input plus fixed strings; Ask returns a canned deferral sentence. The Understand/Decide stages of the loop do not exist yet.
-- Four product-value scenarios are recorded as open **FAIL** against the current behavior (echo briefs, boilerplate uncertainty, unearned trust labels, non-answer Ask) in `docs/sot/05_PRODUCT_VALUE_VERIFICATION_STANDARD.md`. They flip only with VS5 evidence.
+- Brief and Ask now share an immutable runtime model configuration and a local Ollama application path for `ornith:35b` generation plus `qwen3-embedding:0.6b` retrieval embeddings. The same path is exposed through the UI, HTTP surface, and existing native CLI families.
+- Deterministic Plane 1 tests exercise model configuration, scoped retrieval, quoted-evidence prompt boundaries, citation resolution and retrieval allow-lists, and fallback labeling. CI uses `local_test` and mocked model responses; it does not require Ollama or prove model quality.
+- Claim citations can establish source attachment, but lexical overlap cannot earn `evidence_backed` or approval authority. Semantic support remains a separate human-required gate.
+- Search Snapshots, Evidence Bundles, and short-ID Evidence Chunks created before revision binding are intentionally retired as unverified: reads fail closed instead of treating legacy `v0` records as current evidence. Re-run Search and recreate the Bundle and citations from the verified original; there is no silent trust migration.
+- Real runs against the pinned Ollama stack, human semantic-faithfulness review, and external-user usefulness/trust evidence remain **NOT_VERIFIED**. VS5 cannot earn a value verdict until those Plane 2 gates are satisfied.
+- The open product-value rows in `docs/sot/05_PRODUCT_VALUE_VERIFICATION_STANDARD.md` remain authoritative. Implementing a model path does not by itself flip them to PASS.
 
 **Never claimed:** production readiness, live provider execution, real tenancy/security posture, on-prem readiness, external-user validation. No external user has used CornerStone yet; changing that is the point of the current milestone.
 
@@ -50,7 +54,7 @@ This is the VS5 stranger test (`VS5-EXT-001/002`), with a 3-minute unedited sess
 
 | Milestone | Focus | Verdict earned / targeted |
 |---|---|---|
-| VS0–VS4 (closed) | Structural substrate: artifacts, evidence, audit, policy records, UI shell, daily-loop skeleton, verification harness | `STRUCTURAL_READY` (strongest claim these can ever support; `VS4-H01` owner review still open) |
+| VS0–VS4 (structural work closed; human gate open) | Structural substrate: artifacts, evidence, audit, policy records, UI shell, daily-loop skeleton, verification harness | `STRUCTURAL_READY` only; `VS4-H01` owner review was rejected and remains open |
 | **VS5 (active)** | **Citation-grounded, model-backed Brief and Ask; earned trust labels; eval corpus; external stranger test** | targets `VALUE_VERIFIED_EXTERNAL` — `docs/scenario-contracts/VS5_CITATION_GROUNDED_BRIEF_CONTRACT.md` |
 | VS6 (next) | Daily loop: one read-only ingest source, self-filling inbox, morning digest, retrieval at volume, ~20 external users | `docs/scenario-contracts/VS6_DAILY_LOOP_CONTRACT.md` |
 | VS7 (then) | Wedge validation: design partners, willingness-to-pay evidence, keep/kill on off-spine surfaces, dormancy dispositions | `docs/scenario-contracts/VS7_WEDGE_VALIDATION_CONTRACT.md` |
@@ -64,7 +68,7 @@ Structural PASS counts can no longer support product-value claims. Authority: `d
 - **Plane 1 — Structural:** deterministic validators over records, boundaries, labels, audit chains, CLI transcripts. Judge: code. Supports at most `STRUCTURAL_READY`.
 - **Plane 2 — Product value:** grounding, zero fabricated citations, faithfulness, synthesis-beyond-extraction, honest uncertainty, earned trust labels, direct answers, external comprehension and trust (CS-VAL-001..010). Judges: deterministic citation-integrity checks + humans; local LLM judges are advisory only. Supports `VALUE_VERIFIED_LOCAL` / `VALUE_VERIFIED_EXTERNAL`.
 
-**Model assumptions (local-first):** generation `ornith:35b`, embeddings `qwen3-embedding:0.6b`, both via Ollama (verified installed). The deterministic `local_test` provider remains the Plane 1 CI baseline. External model providers are optional and future-facing, named per-scenario when assumed.
+**Model assumptions (local-first):** generation `ornith:35b`, embeddings `qwen3-embedding:0.6b`, both via Ollama. Availability is an operator/runtime prerequisite, not a repository claim. The deterministic `local_test` provider remains the Plane 1 CI baseline. External model providers are optional and future-facing, named per-scenario when assumed.
 
 ## Dormant Systems (honest register)
 
@@ -105,7 +109,7 @@ cornerstone claim create --evidence-bundle-id <id> --statement "..." --json
 
 `artifact download` is the scoped, audited read path for the immutable original. It writes bytes only to the required `--output` path, refuses to replace an existing path unless `--force` is explicit, and never writes binary data to stdout. This is a local read/export, not a product mutation or external action, so it has no dry-run; it does append an Artifact-read audit event. `--json` returns the schema version, tenant/owner/namespace/workspace scope, Artifact ID and checksum, size and media type, evidence refs, and audit refs. Exit codes are `0` success, `1` invalid input or an existing output, `3` original unavailable (missing or outside the requested scope, intentionally non-disclosing), and `5` integrity or output-write failure. The deterministic success, no-overwrite, force, cross-scope, write-failure, and audit transcript is exercised by `ScaffoldCliTests.test_artifact_ingest_show_and_audit_verify`.
 
-**What you will see today:** the full evidence/audit loop working structurally — and a brief that is still extractive (your own text back, labeled and linked). That gap is VS5. Do not demo this as an intelligent product yet.
+**What you will see today:** the evidence/audit loop plus a configured model-backed Brief/Ask path. When the pinned local Ollama stack is available, the product attempts citation-grounded generation; when it is unavailable, the output degrades with an explicit fallback or insufficient-evidence label. This repository state has not yet earned a real-Ollama Plane 2 or product-value verdict. Do not demo it as validated intelligence yet.
 
 ## VS0 Runtime Acceptance Quickstart
 

--- a/packages/cornerstone_cli/acceptance.py
+++ b/packages/cornerstone_cli/acceptance.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -4490,6 +4491,23 @@ def _runtime_acceptance_ref_resolution(
             json_paths[reference] = state_path / "search" / "snapshots" / f"{reference.split(':', 1)[1]}.json"
         elif reference.startswith("evidence_bundle:"):
             json_paths[reference] = state_path / "evidence" / "bundles" / f"{reference.split(':', 1)[1]}.json"
+        elif reference.startswith("derived_representation:"):
+            json_paths[reference] = (
+                state_path
+                / "artifacts"
+                / "derived"
+                / "representations"
+                / f"{reference.split(':', 1)[1]}.json"
+            )
+        elif reference.startswith("evidence_chunk:"):
+            json_paths[reference] = state_path / "evidence" / "chunks" / f"{reference.split(':', 1)[1]}.json"
+        elif reference.startswith("citation_check:"):
+            json_paths[reference] = (
+                state_path
+                / "evidence"
+                / "citation_checks"
+                / f"{reference.split(':', 1)[1]}.json"
+            )
         elif reference.startswith("brief:"):
             json_paths[reference] = state_path / "briefs" / f"{reference.split(':', 1)[1]}.json"
         elif reference.startswith("claim:"):
@@ -4846,10 +4864,14 @@ def _validate_runtime_acceptance_quickstart_report(
         if isinstance(artifact.get("content_identity"), dict)
         else {}
     )
+    accepted_artifact_ids = {
+        f"art_{fixture_sha256[:16]}",
+        f"art_{fixture_sha256}",
+    } if fixture_sha256 else set()
     if (
         fixture_value != "fixtures/vs0/packs/01_artifact_basic/input.txt"
         or fixture_sha256 is None
-        or artifact.get("artifact_id") != f"art_{fixture_sha256[:16]}"
+        or artifact.get("artifact_id") not in accepted_artifact_ids
         or artifact.get("checksum_sha256") != fixture_sha256
         or artifact.get("original_storage_ref") != f"sha256:{fixture_sha256}"
         or content_identity != {"algorithm": "sha256", "value": fixture_sha256}
@@ -5005,6 +5027,9 @@ def _validate_runtime_acceptance_quickstart_report(
         "artifact": "artifact_id",
         "search_snapshot": "search_snapshot_id",
         "evidence_bundle": "evidence_bundle_id",
+        "derived_representation": "derived_representation_id",
+        "evidence_chunk": "evidence_chunk_id",
+        "citation_check": "citation_check_id",
         "brief": "brief_id",
         "claim": "claim_id",
         "namespace_audit_export": "namespace_audit_export_id",
@@ -5020,6 +5045,8 @@ def _validate_runtime_acceptance_quickstart_report(
         f"claim:{claim.get('claim_id')}": claim,
         f"namespace_audit_export:{namespace_export.get('namespace_audit_export_id')}": namespace_export,
     }
+    artifact_derived = artifact.get("derived") if isinstance(artifact.get("derived"), dict) else {}
+    claim_support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
     audit_semantics = {
         f"audit:{event.get('event_id')}": event
         for event in audit_events
@@ -5110,6 +5137,64 @@ def _validate_runtime_acceptance_quickstart_report(
                 ):
                     resolution_records_valid = False
             else:
+                resolution_records_valid = False
+        elif kind == "derived_representation":
+            identity = {
+                "artifact_id": record.get("artifact_id"),
+                "artifact_checksum_sha256": record.get("artifact_checksum_sha256"),
+                "content_checksum_sha256": record.get("content_checksum_sha256"),
+                "representation_type": record.get("representation_type"),
+                "extractor": record.get("extractor"),
+                "extractor_version": record.get("extractor_version"),
+            }
+            if (
+                identifier != f"drv_{_json_value_sha256(identity)}"
+                or record.get("schema_version") != "cs.derived_representation.v1"
+                or record.get("status") != "ready"
+                or record.get("artifact_id") != artifact.get("artifact_id")
+                or record.get("artifact_checksum_sha256") != artifact.get("checksum_sha256")
+                or record.get("content_checksum_sha256") != artifact_derived.get("content_checksum_sha256")
+                or record.get("content_size_bytes") != artifact_derived.get("content_size_bytes")
+                or f"derived_representation:{identifier}" != artifact_derived.get("derived_representation_ref")
+                or record.get("redacted") is not False
+                or record.get("content_checksum_sha256") != artifact.get("checksum_sha256")
+                or record.get("content_size_bytes") != artifact.get("original_size_bytes")
+            ):
+                resolution_records_valid = False
+        elif kind == "evidence_chunk":
+            chunk_base = deepcopy(record)
+            chunk_base.pop("evidence_chunk_id", None)
+            chunk_refs = chunk_base.get("evidence_refs")
+            if isinstance(chunk_refs, list):
+                chunk_base["evidence_refs"] = [
+                    reference
+                    for reference in chunk_refs
+                    if reference != f"evidence_chunk:{identifier}"
+                ]
+            else:
+                resolution_records_valid = False
+            if (
+                identifier != f"chunk_{_json_value_sha256(chunk_base)}"
+                or record.get("scope") != expected_scope
+                or record.get("artifact_id") != artifact.get("artifact_id")
+                or record.get("evidence_bundle_id") != bundle.get("evidence_bundle_id")
+                or record.get("search_snapshot_id") != snapshot.get("search_snapshot_id")
+                or record.get("evidence_revision_sha256") != bundle.get("evidence_revision_sha256")
+                or record.get("derived_representation_ref") != artifact_derived.get("derived_representation_ref")
+                or f"evidence_chunk:{identifier}" not in claim_support.get("citation_refs", [])
+            ):
+                resolution_records_valid = False
+        elif kind == "citation_check":
+            check_base = deepcopy(record)
+            check_base.pop("citation_check_id", None)
+            if (
+                identifier != f"citecheck_{_json_value_sha256(check_base)[:16]}"
+                or record.get("scope") != expected_scope
+                or record.get("status") != "passed"
+                or record.get("output_kind") != "claim_statement"
+                or record.get("citation_refs") != claim_support.get("citation_refs")
+                or f"citation_check:{identifier}" not in claim_support.get("citation_check_refs", [])
+            ):
                 resolution_records_valid = False
         else:
             record_scope = record.get("scope")

--- a/packages/cornerstone_cli/archive_integrity.py
+++ b/packages/cornerstone_cli/archive_integrity.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+def _open_content_readonly(path: Path):
+    """Open a content file without following a final-component symlink."""
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    return os.fdopen(descriptor, "rb")
+
+
+def read_verified_content_file(path: Path, *, checksum_sha256: str, size_bytes: int) -> bytes | None:
+    """Read and freshly verify one regular content file in the same operation."""
+
+    if path.is_symlink() or size_bytes < 0:
+        return None
+    digest = hashlib.sha256()
+    content = bytearray()
+    try:
+        with _open_content_readonly(path) as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                return None
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                content.extend(chunk)
+                digest.update(chunk)
+    except OSError:
+        return None
+    if len(content) != size_bytes or digest.hexdigest() != checksum_sha256:
+        return None
+    return bytes(content)
+
+
+def verify_content_file(path: Path, *, checksum_sha256: str, size_bytes: int) -> bool:
+    """Freshly verify one content-addressed file without metadata caching."""
+
+    if path.is_symlink() or size_bytes < 0:
+        return False
+    digest = hashlib.sha256()
+    actual_size = 0
+    try:
+        with _open_content_readonly(path) as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                return False
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                actual_size += len(chunk)
+                digest.update(chunk)
+    except OSError:
+        return False
+    return actual_size == size_bytes and digest.hexdigest() == checksum_sha256
+
+
+def store_content_atomically(path: Path, data: bytes, *, checksum_sha256: str) -> str:
+    """Durably store verified bytes at a content-addressed path.
+
+    The final path is never written in place. A correct existing file is reused;
+    a corrupt or interrupted file is repaired through an atomic replacement.
+    """
+
+    actual_checksum = hashlib.sha256(data).hexdigest()
+    if actual_checksum != checksum_sha256:
+        raise ValueError("Content checksum does not match the requested storage identity.")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existed_before = path.exists() or path.is_symlink()
+    if verify_content_file(path, checksum_sha256=checksum_sha256, size_bytes=len(data)):
+        return "existing"
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if not verify_content_file(
+            temporary_path,
+            checksum_sha256=checksum_sha256,
+            size_bytes=len(data),
+        ):
+            raise OSError("Temporary content-addressed write failed verification.")
+        os.replace(temporary_path, path)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        directory_fd = os.open(path.parent, directory_flags)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    if not verify_content_file(path, checksum_sha256=checksum_sha256, size_bytes=len(data)):
+        raise OSError("Final content-addressed write failed verification.")
+    return "repaired" if existed_before else "created"

--- a/packages/cornerstone_cli/main.py
+++ b/packages/cornerstone_cli/main.py
@@ -858,6 +858,18 @@ def command_artifact_ingest(args: argparse.Namespace) -> int:
             payload["errors"].append({"code": "CS_ARTIFACT_STORAGE_ERROR", "message": str(error)})
             print_payload(payload, args.json)
             return EXIT_RUNTIME_FAILURE
+        if result.get("status") == "integrity_failed":
+            payload["status"] = "failed"
+            payload["errors"].append(
+                {
+                    "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                    "message": "An existing Artifact record failed content-identity verification.",
+                    "artifact_id": result.get("artifact_id"),
+                    "reason": result.get("reason"),
+                }
+            )
+            print_payload(payload, args.json)
+            return EXIT_RUNTIME_FAILURE
         artifact = result["artifact"]
         audit_event = result["audit_event"]
         audit_events = result.get("audit_events", [audit_event])
@@ -896,6 +908,19 @@ def command_artifact_ingest(args: argparse.Namespace) -> int:
             print_payload(payload, args.json)
             return EXIT_RUNTIME_FAILURE
 
+        if result.get("status") == "integrity_failed":
+            payload["status"] = "failed"
+            payload["errors"].append(
+                {
+                    "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                    "message": "An existing Artifact record failed content-identity verification.",
+                    "artifact_id": result.get("artifact_id"),
+                    "reason": result.get("reason"),
+                }
+            )
+            print_payload(payload, args.json)
+            return EXIT_RUNTIME_FAILURE
+
         artifact = result["artifact"]
         audit_event = result["audit_event"]
         audit_events = result.get("audit_events", [audit_event])
@@ -916,6 +941,9 @@ def command_artifact_ingest(args: argparse.Namespace) -> int:
             f"storage:{artifact['original_storage_ref']}",
         ]
     )
+    derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+    if derived_ref:
+        payload["evidence_refs"].append(str(derived_ref))
     payload["audit_refs"].extend(f"audit:{event['event_id']}" for event in audit_events)
     payload["policy_decision_refs"].extend(f"policy:{decision['id']}" for decision in policy_decisions)
     if policy_decisions:
@@ -954,7 +982,31 @@ def command_artifact_show(args: argparse.Namespace) -> int:
         payload["errors"].append({"code": "CS_SCOPE_DENIED", "message": "Artifact is outside the requested scope."})
         print_payload(payload, args.json)
         return EXIT_SCOPE_DENIED
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                "message": "Artifact record failed content-identity verification.",
+                "artifact_id": args.artifact_id,
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
     artifact = result["record"]
+    if not store.original_available(artifact):
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                "message": "Artifact original failed content-identity verification.",
+                "artifact_id": args.artifact_id,
+                "reason": "artifact_original_identity_mismatch",
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
     audit_event = result["audit_event"]
     artifact_detail = dict(artifact)
     artifact_detail["derived_text_preview"] = store.derived_text_preview(artifact)
@@ -969,7 +1021,12 @@ def command_artifact_show(args: argparse.Namespace) -> int:
         }
     )
     payload["artifact"] = artifact_detail
-    payload["evidence_refs"].append(f"artifact:{artifact['artifact_id']}")
+    payload["evidence_refs"].extend(
+        [f"artifact:{artifact['artifact_id']}", f"storage:{artifact.get('original_storage_ref')}"]
+    )
+    derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+    if derived_ref:
+        payload["evidence_refs"].append(str(derived_ref))
     payload["evidence_refs"].extend(f"claim:{claim['claim_id']}" for claim in artifact_detail["related_claims"])
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
@@ -9616,6 +9673,18 @@ def command_search_snapshot_show(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_SCOPE_DENIED
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_SEARCH_SNAPSHOT_INTEGRITY_FAILED",
+                "message": "Search snapshot failed revision-integrity verification.",
+                "search_snapshot_id": args.search_snapshot_id,
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
     snapshot = result["snapshot"]
     audit_event = result["audit_event"]
     payload["search_snapshot"] = snapshot
@@ -9671,8 +9740,9 @@ def command_evidence_bundle_create(args: argparse.Namespace) -> int:
         payload["errors"].append(
             {
                 "code": "CS_EVIDENCE_ARTIFACT_INTEGRITY_FAILED",
-                "message": "Evidence Bundle creation requires every source original to pass integrity checks.",
+                "message": "Evidence Bundle creation requires the complete Search, original, and Derived Representation chain to pass integrity checks.",
                 "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
             }
         )
         print_payload(payload, args.json)
@@ -9696,6 +9766,11 @@ def command_evidence_bundle_create(args: argparse.Namespace) -> int:
         ]
     )
     payload["evidence_refs"].extend(f"artifact:{item['artifact_id']}" for item in bundle.get("evidence_items", []))
+    payload["evidence_refs"].extend(
+        str(item["derived_representation_ref"])
+        for item in bundle.get("evidence_items", [])
+        if isinstance(item, dict) and item.get("derived_representation_ref")
+    )
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -9731,6 +9806,19 @@ def command_evidence_bundle_show(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_SCOPE_DENIED
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_EVIDENCE_BUNDLE_INTEGRITY_FAILED",
+                "message": "Evidence Bundle failed revision or source-integrity verification.",
+                "evidence_bundle_id": args.evidence_bundle_id,
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
 
     bundle = result["bundle"]
     audit_event = result["audit_event"]
@@ -9750,6 +9838,11 @@ def command_evidence_bundle_show(args: argparse.Namespace) -> int:
         ]
     )
     payload["evidence_refs"].extend(f"artifact:{item['artifact_id']}" for item in bundle.get("evidence_items", []))
+    payload["evidence_refs"].extend(
+        str(item["derived_representation_ref"])
+        for item in bundle.get("evidence_items", [])
+        if isinstance(item, dict) and item.get("derived_representation_ref")
+    )
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -9784,6 +9877,19 @@ def command_evidence_view(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_SCOPE_DENIED
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_EVIDENCE_VIEW_INTEGRITY_FAILED",
+                "message": "Evidence Viewer could not verify the bound Bundle, original, or Derived Representation.",
+                "evidence_bundle_id": args.evidence_bundle_id,
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
 
     viewer = result["viewer"]
     audit_event = result["audit_event"]
@@ -9805,6 +9911,11 @@ def command_evidence_view(args: argparse.Namespace) -> int:
         ]
     )
     payload["evidence_refs"].extend(f"artifact:{item['artifact_id']}" for item in viewer.get("viewer_items", []))
+    payload["evidence_refs"].extend(
+        str(item.get("derived", {}).get("metadata", {}).get("derived_representation_ref"))
+        for item in viewer.get("viewer_items", [])
+        if item.get("derived", {}).get("metadata", {}).get("derived_representation_ref")
+    )
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -9852,6 +9963,19 @@ def command_brief_create(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_EVIDENCE_MISSING
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_BRIEF_EVIDENCE_INTEGRITY_FAILED",
+                "message": "Brief creation requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                "evidence_bundle_id": args.evidence_bundle_id,
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
 
     brief = result["brief"]
     audit_event = result["audit_event"]
@@ -9878,6 +10002,7 @@ def command_brief_create(args: argparse.Namespace) -> int:
         ]
     )
     payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
+    payload["evidence_refs"].extend(evidence.get("derived_representation_refs", []))
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -9934,6 +10059,7 @@ def command_brief_show(args: argparse.Namespace) -> int:
         ]
     )
     payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
+    payload["evidence_refs"].extend(evidence.get("derived_representation_refs", []))
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -9999,6 +10125,20 @@ def command_claim_create(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_EVIDENCE_MISSING
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED",
+                "message": "Claim creation requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                "brief_id": args.brief_id,
+                "evidence_bundle_id": args.evidence_bundle_id,
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
 
     claim = result["claim"]
     audit_event = result["audit_event"]
@@ -10021,6 +10161,7 @@ def command_claim_create(args: argparse.Namespace) -> int:
     if related_brief.get("brief_id"):
         payload["evidence_refs"].append(f"brief:{related_brief['brief_id']}")
     payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
+    payload["evidence_refs"].extend(evidence.get("derived_representation_refs", []))
     statement_support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
     payload["evidence_refs"].extend(statement_support.get("citation_refs", []))
     payload["evidence_refs"].extend(statement_support.get("citation_check_refs", []))
@@ -10071,6 +10212,16 @@ def command_claim_approve(args: argparse.Namespace) -> int:
         payload["ids"]["search_snapshot_id"] = evidence["search_snapshot_id"]
     payload["claim"] = claim
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
+    payload["evidence_refs"].append(f"claim:{claim['claim_id']}")
+    if evidence.get("evidence_bundle_id"):
+        payload["evidence_refs"].append(f"evidence_bundle:{evidence['evidence_bundle_id']}")
+    if evidence.get("search_snapshot_id"):
+        payload["evidence_refs"].append(f"search_snapshot:{evidence['search_snapshot_id']}")
+    payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
+    payload["evidence_refs"].extend(evidence.get("derived_representation_refs", []))
+    support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
+    payload["evidence_refs"].extend(support.get("citation_refs", []))
+    payload["evidence_refs"].extend(support.get("citation_check_refs", []))
     if result.get("status") == "evidence_required":
         payload["status"] = "failed"
         payload["errors"].append(
@@ -10101,18 +10252,33 @@ def command_claim_approve(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_EVIDENCE_MISSING
+    if result.get("status") == "semantic_support_required":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED",
+                "message": "Claim approval requires statement-level semantic support for the exact cited Evidence Bundle revision.",
+                "resolution_path": [
+                    "Review the exact Claim statement against every cited span.",
+                    "Record semantic support separately from the later owner approval decision.",
+                    "Keep the Claim as Draft / Source supported until that review Interface exists.",
+                ],
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_EVIDENCE_MISSING
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED",
+                "message": "Claim approval requires the exact revision-bound evidence chain to pass integrity verification.",
+                "reason": claim.get("evidence_integrity", {}).get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
 
-    payload["evidence_refs"].extend(
-        [
-            f"claim:{claim['claim_id']}",
-            f"evidence_bundle:{evidence['evidence_bundle_id']}",
-            f"search_snapshot:{evidence['search_snapshot_id']}",
-        ]
-    )
-    payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
-    support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
-    payload["evidence_refs"].extend(support.get("citation_refs", []))
-    payload["evidence_refs"].extend(support.get("citation_check_refs", []))
     print_payload(payload, args.json)
     return EXIT_SUCCESS
 
@@ -10163,6 +10329,10 @@ def command_claim_show(args: argparse.Namespace) -> int:
     if evidence.get("search_snapshot_id"):
         payload["evidence_refs"].append(f"search_snapshot:{evidence['search_snapshot_id']}")
     payload["evidence_refs"].extend(evidence.get("artifact_refs", []))
+    payload["evidence_refs"].extend(evidence.get("derived_representation_refs", []))
+    support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
+    payload["evidence_refs"].extend(support.get("citation_refs", []))
+    payload["evidence_refs"].extend(support.get("citation_check_refs", []))
     payload["audit_refs"].append(f"audit:{audit_event['event_id']}")
     print_payload(payload, args.json)
     return EXIT_SUCCESS
@@ -10175,7 +10345,7 @@ def command_claim_basis_export(args: argparse.Namespace) -> int:
     result = store.export_claim_basis(args.claim_id, requested_scope)
     payload = base_response("cornerstone claim basis-export", "success", root)
     payload.update(requested_scope)
-    if result.get("status") in {"not_found", "scope_denied", "evidence_required"}:
+    if result.get("status") in {"not_found", "scope_denied", "evidence_required", "integrity_failed"}:
         exit_code = _record_command_failure(payload, result, resource_label="CLAIM_BASIS")
         print_payload(payload, args.json)
         return exit_code
@@ -10220,11 +10390,22 @@ def _record_command_failure(payload: dict[str, Any], result: dict[str, Any], *, 
         payload["errors"].append(
             {
                 "code": f"CS_{resource_label}_EVIDENCE_REQUIRED",
-                "message": "This record requires evidence-backed source material.",
+                "message": "This record requires revision-bound source material.",
                 "resource": result.get("resource"),
             }
         )
         return EXIT_EVIDENCE_MISSING
+    if status == "integrity_failed":
+        payload["errors"].append(
+            {
+                "code": f"CS_{resource_label}_INTEGRITY_FAILED",
+                "message": "The revision-bound source chain failed integrity verification.",
+                "resource": result.get("resource"),
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        return EXIT_RUNTIME_FAILURE
     payload["errors"].append(
         {
             "code": f"CS_{resource_label}_INVALID",
@@ -15708,11 +15889,23 @@ def command_conversation_start(args: argparse.Namespace) -> int:
     root = repo_root()
     store = LocalRuntimeStore(state_dir(root, args))
     requested_scope = scope_args(args)
-    result = store.start_conversation(args.message, requested_scope)
-    conversation = result["conversation"]
-    artifact = result["artifact"]
     payload = base_response("cornerstone conversation start", "success", root)
     payload.update(requested_scope)
+    result = store.start_conversation(args.message, requested_scope)
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                "message": "The conversation source could not be saved because an existing Artifact record failed content-identity verification.",
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
+    conversation = result["conversation"]
+    artifact = result["artifact"]
     payload["conversation"] = conversation
     payload["artifact"] = artifact
     payload["ids"].update(
@@ -15767,6 +15960,31 @@ def command_conversation_promote(args: argparse.Namespace) -> int:
         )
         print_payload(payload, args.json)
         return EXIT_SCOPE_DENIED
+    if result.get("status") == "evidence_required":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_CONVERSATION_PROMOTION_EVIDENCE_REQUIRED",
+                "message": "Conversation promotion requires a non-empty Evidence Bundle.",
+                "evidence_bundle_id": args.evidence_bundle_id,
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_EVIDENCE_MISSING
+    if result.get("status") == "integrity_failed":
+        payload["status"] = "failed"
+        payload["errors"].append(
+            {
+                "code": "CS_CONVERSATION_PROMOTION_EVIDENCE_INTEGRITY_FAILED",
+                "message": "Conversation promotion requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                "conversation_id": args.conversation_id,
+                "evidence_bundle_id": args.evidence_bundle_id,
+                "artifact_id": result.get("artifact_id"),
+                "reason": result.get("reason"),
+            }
+        )
+        print_payload(payload, args.json)
+        return EXIT_RUNTIME_FAILURE
     if result.get("status") == "unsafe_source_denied":
         policy_decision = result.get("policy_decision", {})
         conversation = result.get("conversation", {})
@@ -24930,7 +25148,7 @@ def build_parser() -> argparse.ArgumentParser:
     claim_create.add_argument("--json", action="store_true", help="Emit JSON output")
     claim_create.set_defaults(func=command_claim_create)
 
-    claim_approve = claim_sub.add_parser("approve", help="Approve an evidence-backed claim")
+    claim_approve = claim_sub.add_parser("approve", help="Check a claim for owner-approval eligibility")
     claim_approve.add_argument("claim_id", help="Claim ID")
     add_state_argument(claim_approve)
     add_scope_arguments(claim_approve)

--- a/packages/cornerstone_cli/product_access.py
+++ b/packages/cornerstone_cli/product_access.py
@@ -80,11 +80,23 @@ class ProductAccessApplication:
                 return loaded
             snapshot = loaded["snapshot"]
             audit_event = loaded["audit_event"]
-            query_matches = str(snapshot.get("query") or "") == redact_text(query)
-            if snapshot.get("query_sha256"):
-                query_matches = query_matches or str(snapshot.get("query_sha256")) == hashlib.sha256(
-                    query.encode("utf-8")
-                ).hexdigest()
+            persisted_query = str(snapshot.get("query") or "")
+            query_digest = str(snapshot.get("query_sha256") or "").strip().lower()
+            if query_digest:
+                # Current snapshots bind pagination to the exact raw query.  The
+                # redacted display value is deliberately not an identity key:
+                # two different secrets can both persist as ``[REDACTED]``.
+                query_matches = query_digest == hashlib.sha256(query.encode("utf-8")).hexdigest()
+            else:
+                # Legacy snapshots predate query_sha256.  Reuse is safe only
+                # when redaction did not alter the query, so equality remains
+                # exact rather than collapsing secret-bearing inputs.
+                redacted_query = redact_text(query)
+                query_matches = (
+                    query == redacted_query
+                    and "[REDACTED]" not in persisted_query
+                    and persisted_query == query
+                )
             if not query_matches:
                 return {"status": "snapshot_query_mismatch", "search_snapshot": snapshot}
             if str(snapshot.get("search_mode") or "evidence") != mode:

--- a/packages/cornerstone_cli/product_runtime.py
+++ b/packages/cornerstone_cli/product_runtime.py
@@ -37,7 +37,6 @@ DEFAULT_SCOPE = {
     "namespace_id": "personal",
     "workspace_id": "default",
 }
-
 API_ROUTES = [
     "GET /health",
     "GET /ready",
@@ -2784,7 +2783,7 @@ Search phrase: alpha-evidence-anchor.</code>
       const descriptions = {{
         "Inbox": "Return to the selected work item from Ops Inbox.",
         "Brief": "Review findings, gaps, and supporting evidence.",
-        "Claim": "Keep the claim candidate evidence-backed before approval.",
+        "Claim": "Keep the Claim as a Draft until source support and statement-level semantic review are complete.",
         "Memory/Wiki": "Review memory or wiki candidate before durable use.",
         "Action": "Preview local/mock action and approval boundary.",
         "Learn": "Keep outcomes and corrections as review candidates."
@@ -2823,7 +2822,7 @@ Search phrase: alpha-evidence-anchor.</code>
       const mismatchVisible = setRecoveryRow(
         "lineage-mismatch",
         "Different journey",
-        mismatch.product_message || "Loop View did not combine work items from different evidence-backed journeys.",
+        mismatch.product_message || "Loop View did not combine work items from different source-linked journeys.",
         "No new journey or activity record was created."
       );
       container.dataset.vs4LoopRecoveryStates = "visible";
@@ -5893,16 +5892,52 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if result.get("status") == "scope_denied":
             self._send_json(_json_response("denied", errors=[{"code": "CS_SCOPE_DENIED", "message": "Artifact is outside the requested scope."}]), 403)
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                            "message": "Artifact record failed content-identity verification.",
+                            "artifact_id": artifact_id,
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         artifact = result["record"]
+        if not self.store.original_available(artifact):
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                            "message": "Artifact original failed content-identity verification.",
+                            "artifact_id": artifact_id,
+                            "reason": "artifact_original_identity_mismatch",
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         event = result["audit_event"]
         detail = dict(artifact)
         detail["derived_text_preview"] = self.store.derived_text_preview(artifact)
         detail["ontology_context"] = self.store.ontology_context_for_artifact(artifact_id, scope)
+        derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+        refs = [f"artifact:{artifact_id}", f"storage:{artifact.get('original_storage_ref')}"]
+        if derived_ref:
+            refs.append(str(derived_ref))
         self._send_json(
             _json_response(
                 "success",
                 artifact=detail,
-                evidence_refs=[f"artifact:{artifact_id}"],
+                evidence_refs=refs,
                 audit_refs=[f"audit:{event['event_id']}"],
             )
         )
@@ -5915,6 +5950,22 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
             return
         if result.get("status") == "scope_denied":
             self._send_json(_json_response("denied", errors=[{"code": "CS_SCOPE_DENIED", "message": "Search snapshot is outside the requested scope."}]), 403)
+            return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_SEARCH_SNAPSHOT_INTEGRITY_FAILED",
+                            "message": "Search snapshot failed revision-integrity verification.",
+                            "search_snapshot_id": snapshot_id,
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
             return
         snapshot = result["snapshot"]
         event = result["audit_event"]
@@ -5936,12 +5987,36 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if result.get("status") == "scope_denied":
             self._send_json(_json_response("denied", errors=[{"code": "CS_SCOPE_DENIED", "message": "Evidence bundle is outside the requested scope."}]), 403)
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_EVIDENCE_BUNDLE_INTEGRITY_FAILED",
+                            "message": "Evidence Bundle failed revision or source-integrity verification.",
+                            "evidence_bundle_id": bundle_id,
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         bundle = result["bundle"]
+        refs = [f"evidence_bundle:{bundle_id}", f"search_snapshot:{bundle['search_snapshot_id']}"]
+        refs.extend(f"artifact:{item['artifact_id']}" for item in bundle.get("evidence_items", []))
+        refs.extend(
+            str(item["derived_representation_ref"])
+            for item in bundle.get("evidence_items", [])
+            if isinstance(item, dict) and item.get("derived_representation_ref")
+        )
         self._send_json(
             _json_response(
                 "success",
                 evidence_bundle=bundle,
-                evidence_refs=[f"evidence_bundle:{bundle_id}", f"search_snapshot:{bundle['search_snapshot_id']}"],
+                evidence_refs=list(dict.fromkeys(refs)),
                 audit_refs=[f"audit:{result['audit_event']['event_id']}"],
             )
         )
@@ -5963,6 +6038,7 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if evidence.get("search_snapshot_id"):
             refs.append(f"search_snapshot:{evidence['search_snapshot_id']}")
         refs.extend(evidence.get("artifact_refs", []))
+        refs.extend(evidence.get("derived_representation_refs", []))
         self._send_json(
             _json_response(
                 "success",
@@ -5981,7 +6057,19 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if result.get("status") == "scope_denied":
             self._send_json(_json_response("denied", errors=[{"code": "CS_SCOPE_DENIED", "message": "Claim is outside the requested scope."}]), 403)
             return
-        self._send_json(_json_response("success", claim=result["record"], evidence_refs=[f"claim:{claim_id}"], audit_refs=[f"audit:{result['audit_event']['event_id']}"]))
+        claim = result["record"]
+        evidence = claim.get("evidence_bundle") if isinstance(claim.get("evidence_bundle"), dict) else {}
+        support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
+        refs = [f"claim:{claim_id}"]
+        if evidence.get("evidence_bundle_id"):
+            refs.append(f"evidence_bundle:{evidence['evidence_bundle_id']}")
+        if evidence.get("search_snapshot_id"):
+            refs.append(f"search_snapshot:{evidence['search_snapshot_id']}")
+        refs.extend(evidence.get("artifact_refs", []))
+        refs.extend(evidence.get("derived_representation_refs", []))
+        refs.extend(support.get("citation_refs", []))
+        refs.extend(support.get("citation_check_refs", []))
+        self._send_json(_json_response("success", claim=claim, evidence_refs=list(dict.fromkeys(refs)), audit_refs=[f"audit:{result['audit_event']['event_id']}"]))
 
     def _show_memory(self, memory_id: str) -> None:
         scope = self._query_scope()
@@ -6037,7 +6125,27 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                 scope,
                 source_ref=str(body.get("source_ref", "home.drop_text")),
             )
+            if result.get("status") == "integrity_failed":
+                self._send_json(
+                    _json_response(
+                        "failed",
+                        errors=[
+                            {
+                                "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                                "message": "An existing Artifact record failed content-identity verification.",
+                                "artifact_id": result.get("artifact_id"),
+                                "reason": result.get("reason"),
+                            }
+                        ],
+                    ),
+                    409,
+                )
+                return
             artifact = result["artifact"]
+            derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+            evidence_refs = [f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"]
+            if derived_ref:
+                evidence_refs.append(str(derived_ref))
             self._send_json(
                 _json_response(
                     "success",
@@ -6046,7 +6154,7 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                     text_ingest=True,
                     trust_forced_untrusted=result.get("trust_forced_untrusted", False),
                     trust_downgraded=result.get("trust_downgraded", False),
-                    evidence_refs=[f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"],
+                    evidence_refs=evidence_refs,
                     audit_refs=[f"audit:{result['audit_event']['event_id']}"],
                     policy_decision_refs=[],
                 )
@@ -6069,14 +6177,34 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
             trust=str(body.get("trust", "untrusted")),
             lineage_from=body.get("lineage_from") if isinstance(body.get("lineage_from"), str) else None,
         )
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                            "message": "An existing Artifact record failed content-identity verification.",
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         artifact = result["artifact"]
         policy_decisions = result.get("policy_decisions", [])
+        derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+        evidence_refs = [f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"]
+        if derived_ref:
+            evidence_refs.append(str(derived_ref))
         self._send_json(
             _json_response(
                 "success",
                 artifact=artifact,
                 deduplicated=result.get("deduplicated", False),
-                evidence_refs=[f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"],
+                evidence_refs=evidence_refs,
                 audit_refs=[f"audit:{event['event_id']}" for event in result.get("audit_events", [result["audit_event"]])],
                 policy_decision_refs=[f"policy:{decision['id']}" for decision in policy_decisions],
                 policy_decisions=policy_decisions,
@@ -6098,14 +6226,34 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                 error.status_code,
             )
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                            "message": "An existing Artifact record failed content-identity verification.",
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         artifact = result["artifact"]
+        derived_ref = artifact.get("derived", {}).get("derived_representation_ref") or artifact.get("derived", {}).get("representation_ref")
+        evidence_refs = [f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"]
+        if derived_ref:
+            evidence_refs.append(str(derived_ref))
         self._send_json(
             _json_response(
                 "success",
                 artifact=artifact,
                 deduplicated=result.get("deduplicated", False),
                 file_ingest=True,
-                evidence_refs=[f"artifact:{artifact['artifact_id']}", f"storage:{artifact['original_storage_ref']}"],
+                evidence_refs=evidence_refs,
                 audit_refs=[f"audit:{event['event_id']}" for event in result.get("audit_events", [result["audit_event"]])],
                 policy_decision_refs=[f"policy:{decision['id']}" for decision in result.get("policy_decisions", [])],
             )
@@ -6150,6 +6298,22 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
             self._send_json(_json_response("failed", errors=[{"code": "CS_CONVERSATION_MESSAGE_REQUIRED", "message": "Conversation message is required."}]), 400)
             return
         result = self.store.start_conversation(message, scope)
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+                            "message": "The conversation source could not be saved because an existing Artifact record failed content-identity verification.",
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         conversation = result["conversation"]
         artifact = result["artifact"]
         self._send_json(
@@ -6223,6 +6387,24 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                     errors=[{"code": "CS_CONVERSATION_PROMOTION_EVIDENCE_REQUIRED", "message": "Conversation promotion requires an Evidence Bundle."}],
                 ),
                 400,
+            )
+            return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_CONVERSATION_PROMOTION_EVIDENCE_INTEGRITY_FAILED",
+                            "message": "Conversation promotion requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                            "conversation_id": conversation_id,
+                            "evidence_bundle_id": body.get("evidence_bundle_id"),
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
             )
             return
         if result.get("status") == "unsafe_source_denied":
@@ -6325,6 +6507,22 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if result.get("status") == "scope_denied":
             self._send_json(_json_response("denied", errors=[{"code": "CS_SCOPE_DENIED", "message": "Search snapshot is outside the requested scope."}]), 403)
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_SEARCH_SNAPSHOT_INTEGRITY_FAILED",
+                            "message": "Search snapshot failed revision-integrity verification.",
+                            "snapshot_id": body.get("snapshot_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         if result.get("status") != "success":
             self._send_json(
                 _json_response(
@@ -6386,8 +6584,9 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                     errors=[
                         {
                             "code": "CS_EVIDENCE_ARTIFACT_INTEGRITY_FAILED",
-                            "message": "Evidence Bundle creation requires every source original to pass integrity checks.",
+                            "message": "Evidence Bundle creation requires the complete Search, original, and Derived Representation chain to pass integrity checks.",
                             "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
                         }
                     ],
                 ),
@@ -6395,11 +6594,18 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
             )
             return
         bundle = result["bundle"]
+        refs = [f"evidence_bundle:{bundle['evidence_bundle_id']}", f"search_snapshot:{bundle['search_snapshot_id']}"]
+        refs.extend(f"artifact:{item['artifact_id']}" for item in bundle.get("evidence_items", []))
+        refs.extend(
+            str(item["derived_representation_ref"])
+            for item in bundle.get("evidence_items", [])
+            if isinstance(item, dict) and item.get("derived_representation_ref")
+        )
         self._send_json(
             _json_response(
                 "success",
                 evidence_bundle=bundle,
-                evidence_refs=[f"evidence_bundle:{bundle['evidence_bundle_id']}", f"search_snapshot:{bundle['search_snapshot_id']}"],
+                evidence_refs=list(dict.fromkeys(refs)),
                 audit_refs=[f"audit:{result['audit_event']['event_id']}"],
             )
         )
@@ -6422,6 +6628,23 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                 400,
             )
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_BRIEF_EVIDENCE_INTEGRITY_FAILED",
+                            "message": "Brief creation requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                            "evidence_bundle_id": body.get("evidence_bundle_id"),
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         brief = result["brief"]
         evidence = brief.get("evidence_bundle", {})
         refs = [f"brief:{brief['brief_id']}"]
@@ -6430,6 +6653,7 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if evidence.get("search_snapshot_id"):
             refs.append(f"search_snapshot:{evidence['search_snapshot_id']}")
         refs.extend(evidence.get("artifact_refs", []))
+        refs.extend(evidence.get("derived_representation_refs", []))
         self._send_json(
             _json_response(
                 "success",
@@ -6480,6 +6704,24 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                 400,
             )
             return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    errors=[
+                        {
+                            "code": "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED",
+                            "message": "Claim creation requires a revision-bound Evidence Bundle with verified originals and Derived Representations.",
+                            "brief_id": brief_id,
+                            "evidence_bundle_id": bundle_id,
+                            "artifact_id": result.get("artifact_id"),
+                            "reason": result.get("reason"),
+                        }
+                    ],
+                ),
+                409,
+            )
+            return
         claim = result["claim"]
         refs = [f"claim:{claim['claim_id']}"]
         evidence = claim.get("evidence_bundle", {})
@@ -6489,6 +6731,7 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
         if related_brief.get("brief_id"):
             refs.append(f"brief:{related_brief['brief_id']}")
         refs.extend(evidence.get("artifact_refs", []))
+        refs.extend(evidence.get("derived_representation_refs", []))
         support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
         refs.extend(support.get("citation_refs", []))
         refs.extend(support.get("citation_check_refs", []))
@@ -6618,6 +6861,57 @@ class VS0RuntimeHandler(BaseHTTPRequestHandler):
                     ],
                 ),
                 400,
+            )
+            return
+        if result.get("status") == "semantic_support_required":
+            claim = result["claim"]
+            evidence = claim.get("evidence_bundle") if isinstance(claim.get("evidence_bundle"), dict) else {}
+            support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}
+            refs = [f"claim:{claim_id}"]
+            if evidence.get("evidence_bundle_id"):
+                refs.append(f"evidence_bundle:{evidence['evidence_bundle_id']}")
+            if evidence.get("search_snapshot_id"):
+                refs.append(f"search_snapshot:{evidence['search_snapshot_id']}")
+            refs.extend(evidence.get("artifact_refs", []))
+            refs.extend(evidence.get("derived_representation_refs", []))
+            refs.extend(support.get("citation_refs", []))
+            refs.extend(support.get("citation_check_refs", []))
+            self._send_json(
+                _json_response(
+                    "failed",
+                    claim=claim,
+                    evidence_refs=list(dict.fromkeys(refs)),
+                    audit_refs=[f"audit:{result['audit_event']['event_id']}"],
+                    errors=[
+                        {
+                            "code": "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED",
+                            "message": "Claim approval requires statement-level semantic support for the exact cited Evidence Bundle revision.",
+                            "resolution_path": [
+                                "Review the exact Claim statement against every cited span.",
+                                "Record semantic support separately from the later owner approval decision.",
+                                "Keep the Claim as Draft / Source supported until that review Interface exists.",
+                            ],
+                        }
+                    ],
+                ),
+                400,
+            )
+            return
+        if result.get("status") == "integrity_failed":
+            self._send_json(
+                _json_response(
+                    "failed",
+                    claim=result["claim"],
+                    audit_refs=[f"audit:{result['audit_event']['event_id']}"],
+                    errors=[
+                        {
+                            "code": "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED",
+                            "message": "Claim approval requires the exact revision-bound evidence chain to pass integrity verification.",
+                            "reason": result["claim"].get("evidence_integrity", {}).get("reason"),
+                        }
+                    ],
+                ),
+                409,
             )
             return
         support = result["claim"].get("statement_support") if isinstance(result["claim"].get("statement_support"), dict) else {}

--- a/packages/cornerstone_cli/product_ui.py
+++ b/packages/cornerstone_cli/product_ui.py
@@ -1266,7 +1266,7 @@ def _topbar(q: str, ctx: dict[str, Any]) -> str:
   <div class="cs-topbar-actions" aria-label="Workspace tools">
     <a class="cs-review-link" href="/inbox" aria-label="Open Review inbox with {h(review_count)} item{"s" if review_count != 1 else ""}">{icon("review")}<span>Review</span><strong>{h(review_count)}</strong></a>
     <details class="cs-help-menu">
-      <summary class="cs-icon-button" aria-label="Help">{icon("help")}</summary>
+      <summary class="cs-icon-button" aria-label="Open help"><span class="cs-help-glyph" aria-hidden="true">?</span></summary>
       <div class="cs-help-popover">
         <strong>Start with Drop or Ask</strong>
         <p>Save a source, ask a question, then open the Brief and its sources before making a decision.</p>

--- a/packages/cornerstone_cli/product_ui.py
+++ b/packages/cornerstone_cli/product_ui.py
@@ -28,6 +28,26 @@ from cornerstone_cli.ui.styles import render_styles as _token_css, style_asset
 from cornerstone_cli.validators import redact_text
 
 PRODUCT_LIST_ROUTES = {"/", "/search", "/artifacts", "/briefs", "/claims", "/actions", "/inbox", "/audit"}
+PRODUCT_RECORD_FAMILIES = frozenset({"artifact", "brief", "claim", "action", "memory"})
+PRODUCT_ROUTE_RECORD_FAMILIES = {
+    "/": PRODUCT_RECORD_FAMILIES,
+    "/search": frozenset(),
+    "/artifacts": frozenset({"artifact", "brief", "claim", "action"}),
+    "/briefs": frozenset({"artifact", "brief"}),
+    "/claims": frozenset({"artifact", "brief", "claim"}),
+    "/actions": frozenset({"artifact", "brief", "claim", "action"}),
+    # Artifact visibility is the root of transitive fixture/owner-only lineage.
+    # Inbox needs it even though it does not render Artifact rows directly.
+    "/inbox": PRODUCT_RECORD_FAMILIES,
+    "/audit": frozenset(),
+}
+PRODUCT_DETAIL_RECORD_FAMILIES = {
+    "artifacts": frozenset({"artifact", "brief", "claim"}),
+    "briefs": frozenset({"artifact", "claim", "action"}),
+    "claims": frozenset({"artifact", "brief", "claim"}),
+    "memories": frozenset({"artifact", "memory"}),
+    "actions": frozenset({"artifact", "brief", "claim", "action"}),
+}
 PRODUCT_SEARCH_TYPES = [
     ("all", "All"),
     ("sources", "Sources"),
@@ -138,6 +158,7 @@ def render_product_page(
     ctx = _build_context(
         store,
         scope,
+        record_families=PRODUCT_ROUTE_RECORD_FAMILIES[route],
         include_audit=route in {"/", "/audit"},
         verify_audit_integrity=route == "/audit",
     )
@@ -254,7 +275,7 @@ def render_owner_reference_images_page(
     store: Any,
     scope: dict[str, str],
 ) -> str:
-    ctx = _build_context(store, scope)
+    ctx = _build_context(store, scope, record_families=frozenset())
     content = _owner_reference_images_page(root)
     return _page(root, "Reference Images", "/review", content, ctx, "")
 
@@ -264,7 +285,7 @@ def render_product_not_found(
     store: Any,
     scope: dict[str, str],
 ) -> str:
-    ctx = _build_context(store, scope)
+    ctx = _build_context(store, scope, record_families=frozenset())
     return _page(root, "Page not found", "/", _not_found("page"), ctx, "")
 
 
@@ -275,16 +296,36 @@ def render_product_detail(
     kind: str,
     record_id: str,
 ) -> tuple[int, str]:
-    ctx = _build_context(store, scope, include_audit=True)
-    access_result = ProductAccessApplication(store).read(
-        RecordReadRequest(
-            record_kind=kind,
-            record_id=record_id,
-            scope=scope,
-            reason="product_ui_detail",
+    try:
+        access_result = ProductAccessApplication(store).read(
+            RecordReadRequest(
+                record_kind=kind,
+                record_id=record_id,
+                scope=scope,
+                reason="product_ui_detail",
+            )
         )
-    )
+    except Exception:
+        # Detail pages have the same fail-closed audit contract as collections:
+        # if the read receipt cannot be recorded, do not render record data or
+        # reveal whether the requested identifier exists.
+        ctx = _build_context(store, scope, record_families=frozenset())
+        ctx["load_errors"].append("page access audit")
+        return 503, _page(
+            root,
+            "Access unavailable",
+            "/",
+            _access_audit_unavailable(),
+            ctx,
+            "",
+        )
     record = access_result.get("record") if isinstance(access_result.get("record"), dict) else None
+    ctx = _build_context(
+        store,
+        scope,
+        record_families=(PRODUCT_DETAIL_RECORD_FAMILIES.get(kind, frozenset()) if record else frozenset()),
+        include_audit=bool(record),
+    )
     audit_event = access_result.get("audit_event") if isinstance(access_result.get("audit_event"), dict) else None
     audit_ref = f"audit:{audit_event['event_id']}" if audit_event and audit_event.get("event_id") else ""
     evidence_kind = {
@@ -355,15 +396,40 @@ def _build_context(
     store: Any,
     scope: dict[str, str],
     *,
+    record_families: frozenset[str] | set[str] | None = None,
     include_audit: bool = False,
     verify_audit_integrity: bool = False,
 ) -> dict[str, Any]:
     load_errors: list[str] = []
-    artifacts = _recent(_safe_records(lambda: store._artifact_records(scope), load_errors, "saved sources"))
-    briefs = _recent(_safe_records(lambda: store._brief_records(scope), load_errors, "briefs"))
-    claims = _recent(_safe_records(lambda: store._claim_records(scope), load_errors, "claims"))
-    actions = _recent(_safe_records(lambda: store._action_records(scope), load_errors, "action drafts"))
-    memories = _recent(_safe_records(lambda: store._memory_records(scope), load_errors, "memory drafts"))
+    selected_families = PRODUCT_RECORD_FAMILIES if record_families is None else frozenset(record_families)
+    unsupported_families = selected_families - PRODUCT_RECORD_FAMILIES
+    if unsupported_families:
+        raise ValueError(f"Unsupported product record families: {sorted(unsupported_families)}")
+    artifacts = (
+        _recent(_safe_records(lambda: store._artifact_records(scope), load_errors, "saved sources"))
+        if "artifact" in selected_families
+        else []
+    )
+    briefs = (
+        _recent(_safe_records(lambda: store._brief_records(scope), load_errors, "briefs"))
+        if "brief" in selected_families
+        else []
+    )
+    claims = (
+        _recent(_safe_records(lambda: store._claim_records(scope), load_errors, "claims"))
+        if "claim" in selected_families
+        else []
+    )
+    actions = (
+        _recent(_safe_records(lambda: store._action_records(scope), load_errors, "action drafts"))
+        if "action" in selected_families
+        else []
+    )
+    memories = (
+        _recent(_safe_records(lambda: store._memory_records(scope), load_errors, "memory drafts"))
+        if "memory" in selected_families
+        else []
+    )
     audit_all = (
         _recent(
             [
@@ -395,7 +461,8 @@ def _build_context(
     actions = [record for record in actions if id(record) not in internal_record_objects]
     memories = [record for record in memories if id(record) not in internal_record_objects]
     inbox = _inbox_items(briefs, claims, actions, memories, scope=scope)
-    inbox_total = len(inbox)
+    inbox_families = {"brief", "claim", "action", "memory"}
+    inbox_total = len(inbox) if inbox_families <= selected_families else None
     return {
         "store": store,
         "scope": scope,
@@ -407,6 +474,7 @@ def _build_context(
         "audit": audit,
         "audit_all": audit_all,
         "audit_integrity": audit_integrity,
+        "loaded_record_families": sorted(selected_families),
         "internal_lineage_refs": internal_lineage_refs,
         "load_errors": list(dict.fromkeys(load_errors)),
         "suggestions": _suggestions(artifacts, briefs, claims),
@@ -617,6 +685,16 @@ def _short_ref(value: Any, length: int = 12) -> str:
     return f"{text[:length]}..."
 
 
+def _breakable_ref(value: Any, chunk_size: int = 16) -> str:
+    """Escape a technical reference while preserving mobile wrap points."""
+
+    text = str(value or "")
+    if not text:
+        return ""
+    size = max(4, chunk_size)
+    return "<wbr>".join(h(text[index : index + size]) for index in range(0, len(text), size))
+
+
 def _artifact_title(record: dict[str, Any] | None) -> str:
     if not record:
         return "Source"
@@ -750,7 +828,7 @@ def _audit_detail(event: dict[str, Any], position: int) -> str:
   <div class="cs-audit-raw-grid">
     <div class="cs-audit-raw-item"><span class="cs-meta">Ledger position</span><strong>{position}</strong></div>
     <div class="cs-audit-raw-item"><span class="cs-meta">Event</span><strong>{h(event_id)}</strong></div>
-    <div class="cs-audit-raw-item"><span class="cs-meta">Subject</span><strong>{h(subject_ref)}</strong></div>
+    <div class="cs-audit-raw-item"><span class="cs-meta">Subject</span><strong>{_breakable_ref(subject_ref)}</strong></div>
     <div class="cs-audit-raw-item"><span class="cs-meta">Event type</span><strong>{h(str(event.get("event_type") or "recorded"))}</strong></div>
     <div class="cs-audit-raw-item"><span class="cs-meta">Event hash</span><strong>{h(event_hash)}</strong></div>
     <div class="cs-audit-raw-item"><span class="cs-meta">Previous hash</span><strong>{h(previous_hash)}</strong></div>
@@ -762,6 +840,9 @@ def _audit_detail(event: dict[str, Any], position: int) -> str:
 
 
 def _brief_label(record: dict[str, Any]) -> tuple[str, str]:
+    evidence_integrity = record.get("evidence_integrity") if isinstance(record.get("evidence_integrity"), dict) else {}
+    if evidence_integrity.get("status") == "failed":
+        return "Integrity issue", "failed"
     output_mode = str(record.get("output_mode") or "").lower()
     trust = str(record.get("trust_label") or record.get("status") or "").lower()
     if output_mode in {"model_cited", "citation_grounded", "ollama_generated"} and trust in {"evidence_backed", "corroborated"}:
@@ -782,6 +863,9 @@ def _brief_source_count(record: dict[str, Any]) -> int:
 
 
 def _brief_label_state(record: dict[str, Any]) -> tuple[str, str]:
+    evidence_integrity = record.get("evidence_integrity") if isinstance(record.get("evidence_integrity"), dict) else {}
+    if evidence_integrity.get("status") == "failed":
+        return "Evidence integrity failed", "failed"
     label_check = record.get("label_check") if isinstance(record.get("label_check"), dict) else {}
     if record.get("presented_as_fact") is True and label_check.get("earned_evidence_backed") is True:
         return "Fact label earned", "evidenceBacked"
@@ -835,6 +919,9 @@ def _brief_summary_text(record: dict[str, Any]) -> str:
 
 
 def _claim_label(record: dict[str, Any]) -> tuple[str, str]:
+    evidence_integrity = record.get("evidence_integrity") if isinstance(record.get("evidence_integrity"), dict) else {}
+    if evidence_integrity.get("status") == "failed":
+        return "Integrity issue", "failed"
     status = str(record.get("status") or "").lower()
     if status == "approved":
         return "Approved", "approved"
@@ -859,6 +946,14 @@ def _claim_evidence_backed_earned(record: dict[str, Any]) -> bool:
         and support.get("approval_eligible") is True
     )
     return trust == "evidence_backed" and (legacy_label_earned or statement_support_earned)
+
+
+def _claim_semantic_support_verified(record: dict[str, Any]) -> bool:
+    support = record.get("statement_support") if isinstance(record.get("statement_support"), dict) else {}
+    return bool(
+        support.get("semantic_support_verified") is True
+        and support.get("semantic_faithfulness_state") == "passed"
+    )
 
 
 def _action_lifecycle(record: dict[str, Any]) -> dict[str, Any]:
@@ -984,11 +1079,23 @@ def _inbox_items(
         )
     for claim in [claim for claim in claims if str(claim.get("status") or "").lower() != "approved"]:
         label, state = _claim_label(claim)
+        evidence_integrity = claim.get("evidence_integrity") if isinstance(claim.get("evidence_integrity"), dict) else {}
+        source_supported = str(
+            (claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {}).get("status")
+            or ""
+        ) == "source_supported"
         items.append(
             {
                 "kind": "Claim",
                 "title": _claim_title(claim),
-                "detail": "Needs source support before it can be approved.",
+                "detail": (
+                    "The linked evidence chain failed integrity verification and must be repaired before review."
+                    if evidence_integrity.get("status") == "failed"
+                    else
+                    "Source support is attached; statement-level semantic review is required before owner approval."
+                    if source_supported
+                    else "Needs source support before semantic review and owner approval."
+                ),
                 "label": label,
                 "state": state,
                 "href": _detail_href("claims", claim.get("claim_id")),
@@ -1199,12 +1306,21 @@ def _page(root: Path, title: str, active: str, content: str, ctx: dict[str, Any]
 
 
 def _nav(active: str, ctx: dict[str, Any]) -> str:
+    loaded = (
+        set(ctx["loaded_record_families"])
+        if "loaded_record_families" in ctx
+        else set(PRODUCT_RECORD_FAMILIES)
+    )
     counts = {
-        "/": len(ctx["artifacts"]),
-        "/search": len(ctx["artifacts"]) + len(ctx["briefs"]) + len(ctx["claims"]) + len(ctx["actions"]),
-        "/artifacts": len(ctx["artifacts"]),
-        "/claims": len(ctx["claims"]),
-        "/actions": len(ctx["actions"]),
+        "/": len(ctx["artifacts"]) if "artifact" in loaded else None,
+        "/search": (
+            len(ctx["artifacts"]) + len(ctx["briefs"]) + len(ctx["claims"]) + len(ctx["actions"])
+            if {"artifact", "brief", "claim", "action"} <= loaded
+            else None
+        ),
+        "/artifacts": len(ctx["artifacts"]) if "artifact" in loaded else None,
+        "/claims": len(ctx["claims"]) if "claim" in loaded else None,
+        "/actions": len(ctx["actions"]) if "action" in loaded else None,
     }
     primary = [
         ("/", "Home"),
@@ -1224,7 +1340,7 @@ def _nav(active: str, ctx: dict[str, Any]) -> str:
 """
 
 
-def _nav_link(href: str, label: str, active: str, count: int) -> str:
+def _nav_link(href: str, label: str, active: str, count: int | None) -> str:
     current = ' aria-current="page"' if href == active else ""
     icon_name = {
         "/": "home",
@@ -1233,25 +1349,43 @@ def _nav_link(href: str, label: str, active: str, count: int) -> str:
         "/claims": "shield-check",
         "/actions": "action",
     }.get(href, "document")
-    return f'<a href="{h(href)}"{current}><span class="cs-nav-mark">{icon(icon_name)}</span><span>{h(label)}</span><span class="cs-nav-count">{h(str(count))}</span></a>'
+    count_text = "" if count is None else str(count)
+    return f'<a href="{h(href)}"{current}><span class="cs-nav-mark">{icon(icon_name)}</span><span>{h(label)}</span><span class="cs-nav-count">{h(count_text)}</span></a>'
 
 
 def _sidebar_status(ctx: dict[str, Any]) -> str:
-    source_count = len(ctx["artifacts"])
+    loaded = (
+        set(ctx["loaded_record_families"])
+        if "loaded_record_families" in ctx
+        else set(PRODUCT_RECORD_FAMILIES)
+    )
+    source_count = len(ctx["artifacts"]) if "artifact" in loaded else None
     scope = ctx.get("scope") if isinstance(ctx.get("scope"), dict) else {}
     workspace = str(scope.get("workspace_id") or "default")
     namespace = str(scope.get("namespace_id") or "personal")
+    source_summary = (
+        f'{source_count} source{"s" if source_count != 1 else ""}'
+        if source_count is not None
+        else "workspace"
+    )
     return f"""
 <a class="cs-workspace-switcher" href="/review" aria-label="Open local workspace settings">
   <span class="cs-workspace-icon">{icon("document")}</span>
-  <span><strong>{h(workspace)}</strong><small>{h(namespace)} · {h(source_count)} source{"s" if source_count != 1 else ""}</small></span>
+  <span><strong>{h(workspace)}</strong><small>{h(namespace)} · {h(source_summary)}</small></span>
   {icon("chevron-right", class_name="cs-icon is-small")}
 </a>
 """
 
 
 def _topbar(q: str, ctx: dict[str, Any]) -> str:
-    review_count = int(ctx.get("inbox_total", len(ctx["inbox"])))
+    raw_review_count = ctx.get("inbox_total", len(ctx["inbox"]))
+    review_count = int(raw_review_count) if raw_review_count is not None else None
+    review_label = (
+        f'Open Review inbox with {review_count} item{"s" if review_count != 1 else ""}'
+        if review_count is not None
+        else "Open Review inbox"
+    )
+    review_count_markup = "" if review_count is None else f"<strong>{h(review_count)}</strong>"
     scope = ctx.get("scope") if isinstance(ctx.get("scope"), dict) else {}
     owner = str(scope.get("owner_id") or "local-user")
     return f"""
@@ -1264,7 +1398,7 @@ def _topbar(q: str, ctx: dict[str, Any]) -> str:
     </form>
   </div>
   <div class="cs-topbar-actions" aria-label="Workspace tools">
-    <a class="cs-review-link" href="/inbox" aria-label="Open Review inbox with {h(review_count)} item{"s" if review_count != 1 else ""}">{icon("review")}<span>Review</span><strong>{h(review_count)}</strong></a>
+    <a class="cs-review-link" href="/inbox" aria-label="{h(review_label)}">{icon("review")}<span>Review</span>{review_count_markup}</a>
     <details class="cs-help-menu">
       <summary class="cs-icon-button" aria-label="Open help"><span class="cs-help-glyph" aria-hidden="true">?</span></summary>
       <div class="cs-help-popover">
@@ -2052,8 +2186,27 @@ def _brief_list_page(ctx: dict[str, Any]) -> str:
 
 def _claim_list_page(ctx: dict[str, Any]) -> str:
     claims = ctx["claims"]
-    supported_count = sum(1 for claim in claims if _evidence_refs(claim))
-    evidence_backed_count = sum(1 for claim in claims if _claim_evidence_backed_earned(claim))
+    supported_count = sum(
+        1
+        for claim in claims
+        if _evidence_refs(claim)
+        and not (
+            isinstance(claim.get("evidence_integrity"), dict)
+            and claim["evidence_integrity"].get("status") == "failed"
+        )
+    )
+    semantic_review_needed_count = sum(
+        1
+        for claim in claims
+        if _evidence_refs(claim)
+        and not (
+            isinstance(claim.get("evidence_integrity"), dict)
+            and claim["evidence_integrity"].get("status") == "failed"
+        )
+        and not _claim_semantic_support_verified(claim)
+        and str(claim.get("status") or "").lower() != "approved"
+    )
+    semantic_reviewed_count = sum(1 for claim in claims if _claim_semantic_support_verified(claim))
     approved_count = sum(1 for claim in claims if str(claim.get("status") or "").lower() == "approved")
     rows = ""
     for claim in claims:
@@ -2069,7 +2222,7 @@ def _claim_list_page(ctx: dict[str, Any]) -> str:
             footer=[
                 ("Evidence refs", f"{source_count} source refs"),
                 ("Trust lane", label),
-                ("Next review step", "Citation checks before evidence-backed"),
+                ("Next review step", "Semantic review before owner approval"),
             ],
             action_label="Review claim",
         )
@@ -2089,7 +2242,7 @@ def _claim_list_page(ctx: dict[str, Any]) -> str:
         ],
         receipts=[
             ("Claim statement", "One decision-ready statement per row."),
-            ("Trust lane", "Draft, source support, evidence-backed after checks, then approved."),
+            ("Trust lane", "Draft, source support, then separate semantic review before owner approval."),
             ("Evidence picker", "Support must stay visible before approval."),
         ],
     )
@@ -2097,18 +2250,18 @@ def _claim_list_page(ctx: dict[str, Any]) -> str:
 <section data-product-surface="claims">
   <div class="cs-page-head">
     <div class="cs-kicker">Claims</div>
-    <h1>Claims that need source support</h1>
-    <p>Promote only statements that can be traced back to saved sources.</p>
+    <h1>Claims under review</h1>
+    <p>Trace each statement to saved sources, then review whether those sources actually support its meaning before owner approval.</p>
   </div>
   <div class="cs-collection-workbench">
     <div>
-      {_collection_summary([("Claims", len(claims)), ("With sources", supported_count), ("Evidence-backed", evidence_backed_count), ("Approved", approved_count)])}
+      {_collection_summary([("Claims", len(claims)), ("With sources", supported_count), ("Semantic review needed", semantic_review_needed_count), ("Approved", approved_count)])}
       <div class="cs-collection-list">{rows}</div>
     </div>
     <aside class="cs-stack">
       <section class="cs-panel flat">
         <h2 class="cs-section-title">Review posture</h2>
-        <p class="cs-muted">Claims can show source support before review. The evidence-backed label stays locked until citation checks earn it.</p>
+        <p class="cs-muted">Claims can show source support, but they stay Draft until statement-level semantic review is recorded separately from owner approval.</p>
         <div class="cs-review-box">
           <a class="cs-button" href="/inbox">Open review inbox</a>
           <a class="cs-button secondary" href="/artifacts">Check sources</a>
@@ -2116,7 +2269,7 @@ def _claim_list_page(ctx: dict[str, Any]) -> str:
       </section>
       <section class="cs-panel flat">
         <h2 class="cs-section-title">Trust ladder</h2>
-        {_claim_trust_ladder(bool(supported_count), bool(evidence_backed_count), bool(approved_count))}
+        {_claim_trust_ladder(bool(supported_count), bool(semantic_reviewed_count), bool(approved_count))}
       </section>
     </aside>
   </div>
@@ -2567,7 +2720,7 @@ def _inbox_journey_recovery_details() -> str:
     </div>
     <div data-vs4-loop-recovery-state="lineage-mismatch" data-vs4-loop-recovery-status="blocked-safe">
       <strong>Different journey</strong>
-      <span>CornerStone did not combine unrelated evidence-backed work. No new journey or activity record was created by the workflow; only this page view was added to History.</span>
+      <span>CornerStone did not combine unrelated source-linked work. No new journey or activity record was created by the workflow; only this page view was added to History.</span>
     </div>
   </div>
 </details>
@@ -2728,7 +2881,7 @@ def _audit_page(
       <div class="cs-audit-row-meta">
         <span>{h(_audit_family(str(event.get("event_type") or "")))}</span>
         <span>{h(_display_date(event))}</span>
-        <span>{h(_audit_record_ref(event) or "No subject reference")}</span>
+        <span>{_breakable_ref(_audit_record_ref(event) or "No subject reference")}</span>
       </div>
     </div>
   </div>
@@ -3581,6 +3734,8 @@ def _claim_detail(ctx: dict[str, Any], claim: dict[str, Any]) -> str:
     source_items = _source_items(ctx, claim)
     source_list = _source_links_from_items(source_items)
     authority = claim.get("authority") if isinstance(claim.get("authority"), dict) else {}
+    evidence_integrity = claim.get("evidence_integrity") if isinstance(claim.get("evidence_integrity"), dict) else {}
+    integrity_failed = evidence_integrity.get("status") == "failed"
     has_sources = bool(source_items)
     is_approved = str(claim.get("status") or "").lower() == "approved"
     evidence_backed_earned = _claim_evidence_backed_earned(claim)
@@ -3608,11 +3763,18 @@ def _claim_detail(ctx: dict[str, Any], claim: dict[str, Any]) -> str:
         denied = denial_events[0]
         details = denied.get("details") if isinstance(denied.get("details"), dict) else {}
         audit_ref = f"audit:{denied.get('event_id')}" if denied.get("event_id") else "Audit reference unavailable"
+        semantic_denial = str(details.get("reason") or "") == "semantic_support_review_required"
+        denial_chip = "Semantic review required" if semantic_denial else "Evidence required"
+        recovery = (
+            "Review the exact statement against every cited span. Semantic support and owner approval remain separate decisions."
+            if semantic_denial
+            else "Return to the source Brief and create a Claim from a citation-checked finding."
+        )
         denial_panel = f"""
 <section class="cs-panel" data-claim-approval-denial="true">
-  <div class="cs-panel-header"><div><h2>Approval blocked</h2><p class="cs-muted">The Claim remains a draft.</p></div>{_chip("Evidence required", "insufficientEvidence")}</div>
+  <div class="cs-panel-header"><div><h2>Approval blocked</h2><p class="cs-muted">The Claim remains a draft.</p></div>{_chip(denial_chip, "insufficientEvidence")}</div>
   <p><strong>Cause:</strong> {h(_plain_runtime_text(details.get("reason") or "Supporting source evidence is missing."))}</p>
-  <p><strong>Recovery:</strong> Return to the source Brief and create a Claim from a citation-checked finding.</p>
+  <p><strong>Recovery:</strong> {h(recovery)}</p>
   <details class="cs-audit-detail"><summary>Denial detail</summary><p><code>{h(audit_ref)}</code></p><p>{h(_plain_runtime_text(details.get("required") or "Supporting evidence is required before approval."))}</p></details>
 </section>
 """
@@ -3659,7 +3821,7 @@ def _claim_detail(ctx: dict[str, Any], claim: dict[str, Any]) -> str:
     else:
         approval_panel = f"""
 <section class="cs-panel cs-decision-panel" data-claim-approval-state="blocked">
-  <div class="cs-panel-header"><div><h2>Approval is not available</h2><p class="cs-muted">{h(blocked_reason)}</p></div>{_chip("Source support needed", "insufficientEvidence")}</div>
+  <div class="cs-panel-header"><div><h2>Approval is not available</h2><p class="cs-muted">{h(blocked_reason)}</p></div>{_chip("Evidence integrity failed" if integrity_failed else "Semantic review required" if has_sources else "Source support needed", "failed" if integrity_failed else "insufficientEvidence")}</div>
   <div class="cs-review-box">{related_brief}</div>
 </section>
 """
@@ -4124,13 +4286,13 @@ def _action_detail(ctx: dict[str, Any], action: dict[str, Any]) -> str:
 """
 
 
-def _claim_trust_ladder(has_sources: bool, evidence_backed_earned: bool, is_approved: bool) -> str:
+def _claim_trust_ladder(has_sources: bool, semantic_support_verified: bool, is_approved: bool) -> str:
     source_class = "is-active" if has_sources else "is-locked"
-    evidence_class = "is-active" if evidence_backed_earned else "is-locked"
+    semantic_class = "is-active" if semantic_support_verified else "is-locked"
     approved_class = "is-active" if is_approved else "is-locked"
     source_note = "Supporting source is attached." if has_sources else "Attach at least one source."
-    evidence_note = "Citation checks earned this label." if evidence_backed_earned else "Locked until citation checks pass."
-    approved_note = "Owner approval recorded." if is_approved else "Requires review first."
+    semantic_note = "Statement-level semantic support is recorded." if semantic_support_verified else "Required before owner approval."
+    approved_note = "Owner approval recorded." if is_approved else "Requires semantic review first."
     return f"""
 <div class="cs-trust-ladder" aria-label="Claim trust ladder">
   <div class="cs-trust-step is-active">
@@ -4141,9 +4303,9 @@ def _claim_trust_ladder(has_sources: bool, evidence_backed_earned: bool, is_appr
     <strong>Source support</strong>
     <span class="cs-meta">{h(source_note)}</span>
   </div>
-  <div class="cs-trust-step {evidence_class}">
-    <strong>Evidence-backed</strong>
-    <span class="cs-meta">{h(evidence_note)}</span>
+  <div class="cs-trust-step {semantic_class}">
+    <strong>Semantic review</strong>
+    <span class="cs-meta">{h(semantic_note)}</span>
   </div>
   <div class="cs-trust-step {approved_class}">
     <strong>Approved</strong>
@@ -4882,14 +5044,13 @@ def _home_script(scope: dict[str, Any]) -> str:
       setBusy(askForm, askButton, true, "Checking", "Ask");
       try {
         setStatus(askStatus, "Checking saved sources...", "loading");
-        const searched = await postJson("/search", {query: question, excluded_source_types: ["conversation_turn"]});
-        const sourceSnapshot = searched.search_snapshot || {};
         const started = await postJson("/conversations", {message: question});
         const conversation = started.conversation || {};
         const id = conversation["conversation" + "_id"];
         if (!id) throw new Error("Conversation was not saved.");
         const answered = await postJson("/conversations/" + encodeURIComponent(id) + "/answers", {question});
         const answer = answered.answer || {};
+        const sourceSnapshot = answered.search_snapshot || {};
         const text = answer.answer || "Draft answer saved. Open the linked sources before using it.";
         const safety = conversation.safety || {};
         if (safety.unsafe_instruction_detected === true) {

--- a/packages/cornerstone_cli/runtime.py
+++ b/packages/cornerstone_cli/runtime.py
@@ -6,17 +6,33 @@ import json
 import os
 import re
 import shutil
+import threading
+from copy import deepcopy
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
-from functools import lru_cache
 from time import perf_counter
 from pathlib import Path
 from typing import Any
 
 from cornerstone_cli.artifacts import normalize_media_type
+from cornerstone_cli.archive_integrity import (
+    read_verified_content_file,
+    store_content_atomically,
+    verify_content_file,
+)
 from cornerstone_cli.product_visibility import context_only_artifact, internal_product_lineage
 from cornerstone_cli.validators import redact_text
+
+
+_ARTIFACT_THREAD_LOCKS: dict[str, threading.RLock] = {}
+_ARTIFACT_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _artifact_thread_lock(lock_path: Path) -> threading.RLock:
+    key = str(lock_path.resolve())
+    with _ARTIFACT_THREAD_LOCKS_GUARD:
+        return _ARTIFACT_THREAD_LOCKS.setdefault(key, threading.RLock())
 
 
 UNSAFE_INSTRUCTION_PATTERNS = [
@@ -111,8 +127,12 @@ OLLAMA_TIMEOUT_SECONDS = 180
 EVIDENCE_CHUNK_MAX_CHARS = 1200
 EVIDENCE_CHUNK_OVERLAP_CHARS = 160
 EVIDENCE_CHUNK_LIMIT = 5
-EVIDENCE_CHUNK_ID_RE = re.compile(r"^chunk_[0-9a-f]{16}$")
-EVIDENCE_CHUNK_REF_RE = re.compile(r"^evidence_chunk:(chunk_[0-9a-f]{16})$")
+EVIDENCE_CHUNK_ID_RE = re.compile(r"^chunk_(?:[0-9a-f]{16}|[0-9a-f]{64})$")
+EVIDENCE_CHUNK_REF_RE = re.compile(r"^evidence_chunk:(chunk_(?:[0-9a-f]{16}|[0-9a-f]{64}))$")
+DERIVED_REPRESENTATION_ID_RE = re.compile(r"^drv_[0-9a-f]{64}$")
+DERIVED_REPRESENTATION_TYPE = "extracted_text"
+DERIVED_EXTRACTOR = "cornerstone.text.redact"
+DERIVED_EXTRACTOR_VERSION = "1"
 
 STRUCTURE_LABELS = {
     "person": ("object", "person"),
@@ -124,26 +144,6 @@ STRUCTURE_LABELS = {
     "claim": ("fact", "claim"),
     "fact": ("fact", "fact"),
 }
-
-
-@lru_cache(maxsize=1024)
-def _original_file_matches(
-    path_value: str,
-    modified_ns: int,
-    size_bytes: int,
-    checksum: str,
-) -> bool:
-    del modified_ns
-    path = Path(path_value)
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-        actual_size = path.stat().st_size
-    except OSError:
-        return False
-    return actual_size == size_bytes and digest.hexdigest() == checksum
 
 
 def _vs5_value_plane_metadata(
@@ -554,6 +554,30 @@ def _json_hash(payload: dict[str, Any]) -> str:
     return sha256_bytes(encoded)
 
 
+def _search_result_revision_sha256(snapshot: dict[str, Any]) -> str:
+    return _json_hash(
+        {
+            "query_sha256": snapshot.get("query_sha256"),
+            "filters": snapshot.get("filters"),
+            "search_mode": snapshot.get("search_mode"),
+            "result_types": snapshot.get("result_types", []),
+            "results": snapshot.get("results", []),
+        }
+    )
+
+
+def _evidence_bundle_revision_sha256(bundle: dict[str, Any]) -> str:
+    return _json_hash(
+        {
+            "search_snapshot_id": bundle.get("search_snapshot_id"),
+            "query_sha256": bundle.get("query_sha256"),
+            "search_result_revision_sha256": bundle.get("search_result_revision_sha256"),
+            "filters": bundle.get("filters"),
+            "evidence_items": bundle.get("evidence_items", []),
+        }
+    )
+
+
 def action_preflight_binding_for_action(action: dict[str, Any]) -> dict[str, Any]:
     artifact_refs = action.get("evidence", {}).get("artifact_refs", [])
     if not isinstance(artifact_refs, list):
@@ -574,12 +598,34 @@ def action_preflight_binding_for_action(action: dict[str, Any]) -> dict[str, Any
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    store_content_atomically(path, encoded, checksum_sha256=sha256_bytes(encoded))
 
 
 def _read_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text())
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected a JSON object in {path}")
+    return payload
+
+
+def _short_content_address_matches(
+    record: dict[str, Any],
+    *,
+    id_key: str,
+    prefix: str,
+    normalized_fields: dict[str, Any] | None = None,
+) -> bool:
+    """Verify the 16-hex record ID that was derived from the persisted payload."""
+
+    record_id = str(record.get(id_key) or "")
+    if not re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{16}}", record_id):
+        return False
+    identity_payload = deepcopy(record)
+    identity_payload.pop(id_key, None)
+    for key, value in (normalized_fields or {}).items():
+        identity_payload[key] = deepcopy(value)
+    return record_id == f"{prefix}{_json_hash(identity_payload)[:16]}"
 
 
 def detect_unsafe_instructions(text: str) -> list[str]:
@@ -762,6 +808,8 @@ class LocalRuntimeStore:
         self.artifact_dir = state_dir / "artifacts"
         self.original_dir = self.artifact_dir / "originals"
         self.record_dir = self.artifact_dir / "records"
+        self.derived_content_dir = self.artifact_dir / "derived" / "content" / "sha256"
+        self.derived_representation_dir = self.artifact_dir / "derived" / "representations"
         self.workspace_dir = state_dir / "workspaces"
         self.conversation_dir = state_dir / "conversations"
         self.mission_dir = state_dir / "missions"
@@ -942,15 +990,28 @@ class LocalRuntimeStore:
         return {"status": "success" if not errors else "failed", "event_count": event_count, "errors": errors}
 
     def artifact_path(self, artifact_id: str, scope: dict[str, str] | None = None) -> Path:
-        if scope is None:
-            return self.record_dir / f"{artifact_id}.json"
-        return self.record_dir / scope_key(scope) / f"{artifact_id}.json"
+        base = self.record_dir if scope is None else self.record_dir / scope_key(scope)
+        return self._safe_record_path(base, artifact_id)
+
+    def _safe_record_path(self, base: Path, record_id: str) -> Path:
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,200}", record_id):
+            raise ValueError("Invalid record id.")
+        resolved_base = base.resolve()
+        path = (resolved_base / f"{record_id}.json").resolve()
+        if path.parent != resolved_base:
+            raise ValueError("Record path escapes its storage directory.")
+        return path
+
+    def derived_representation_path(self, representation_id: str) -> Path:
+        if not DERIVED_REPRESENTATION_ID_RE.fullmatch(representation_id):
+            raise ValueError("Invalid derived representation id.")
+        return self.derived_representation_dir / f"{representation_id}.json"
 
     def search_snapshot_path(self, snapshot_id: str) -> Path:
-        return self.state_dir / "search" / "snapshots" / f"{snapshot_id}.json"
+        return self._safe_record_path(self.state_dir / "search" / "snapshots", snapshot_id)
 
     def evidence_bundle_path(self, bundle_id: str) -> Path:
-        return self.state_dir / "evidence" / "bundles" / f"{bundle_id}.json"
+        return self._safe_record_path(self.state_dir / "evidence" / "bundles", bundle_id)
 
     def evidence_chunk_path(self, chunk_id: str) -> Path:
         if not EVIDENCE_CHUNK_ID_RE.fullmatch(chunk_id):
@@ -962,25 +1023,25 @@ class LocalRuntimeStore:
         return path
 
     def citation_check_path(self, check_id: str) -> Path:
-        return self.citation_check_dir / f"{check_id}.json"
+        return self._safe_record_path(self.citation_check_dir, check_id)
 
     def brief_path(self, brief_id: str) -> Path:
-        return self.state_dir / "briefs" / f"{brief_id}.json"
+        return self._safe_record_path(self.state_dir / "briefs", brief_id)
 
     def claim_path(self, claim_id: str) -> Path:
-        return self.state_dir / "claims" / f"{claim_id}.json"
+        return self._safe_record_path(self.state_dir / "claims", claim_id)
 
     def conversation_path(self, conversation_id: str) -> Path:
-        return self.conversation_dir / f"{conversation_id}.json"
+        return self._safe_record_path(self.conversation_dir, conversation_id)
 
     def workspace_path(self, scope: dict[str, str]) -> Path:
         return self.workspace_dir / f"{scope_key(scope)}.json"
 
     def mission_path(self, mission_id: str) -> Path:
-        return self.mission_dir / f"{mission_id}.json"
+        return self._safe_record_path(self.mission_dir, mission_id)
 
     def action_path(self, action_id: str) -> Path:
-        return self.action_dir / f"{action_id}.json"
+        return self._safe_record_path(self.action_dir, action_id)
 
     def workflow_run_path(self, workflow_run_id: str) -> Path:
         return self.workflow_run_dir / f"{workflow_run_id}.json"
@@ -998,10 +1059,10 @@ class LocalRuntimeStore:
         return self.connector_provider_receipt_dir / f"{receipt_id}.json"
 
     def answer_path(self, answer_id: str) -> Path:
-        return self.answer_dir / f"{answer_id}.json"
+        return self._safe_record_path(self.answer_dir, answer_id)
 
     def memory_path(self, memory_id: str) -> Path:
-        return self.memory_dir / f"{memory_id}.json"
+        return self._safe_record_path(self.memory_dir, memory_id)
 
     def memory_conflict_path(self, conflict_id: str) -> Path:
         return self.memory_conflict_dir / f"{conflict_id}.json"
@@ -1267,7 +1328,13 @@ class LocalRuntimeStore:
     def release_report_path(self, report_id: str) -> Path:
         return self.release_report_dir / f"{report_id}.json"
 
-    def get_artifact(self, artifact_id: str, scope: dict[str, str] | None = None) -> dict[str, Any] | None:
+    def _get_artifact_unchecked(
+        self,
+        artifact_id: str,
+        scope: dict[str, str] | None = None,
+    ) -> dict[str, Any] | None:
+        if not re.fullmatch(r"art_(?:[0-9a-f]{16}|[0-9a-f]{64})", artifact_id):
+            return None
         if scope is not None:
             scoped_path = self.artifact_path(artifact_id, scope)
             if scoped_path.exists():
@@ -1287,11 +1354,78 @@ class LocalRuntimeStore:
             return None
         return _read_json(candidate_paths[0])
 
-    def get_search_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
+    def _artifact_identity_error(
+        self,
+        artifact: dict[str, Any],
+        artifact_id: str,
+        scope: dict[str, str] | None = None,
+    ) -> str | None:
+        if artifact.get("artifact_id") != artifact_id:
+            return "artifact_id_mismatch"
+        if scope is not None and artifact.get("scope") != scope:
+            return "artifact_scope_mismatch"
+
+        # Current and legacy content-addressed Artifact IDs must both remain
+        # bound to the same checksum. Arbitrary path labels are not Artifact
+        # identities and therefore fail closed on every active read.
+        canonical_match = re.fullmatch(r"art_([0-9a-f]{64})", artifact_id)
+        legacy_match = re.fullmatch(r"art_([0-9a-f]{16})", artifact_id)
+        if canonical_match is None and legacy_match is None:
+            return "artifact_id_format_invalid"
+
+        checksum = str(artifact.get("checksum_sha256") or "")
+        expected_size = artifact.get("original_size_bytes")
+        if not re.fullmatch(r"[0-9a-f]{64}", checksum):
+            return "artifact_checksum_invalid"
+        if canonical_match is not None and canonical_match.group(1) != checksum:
+            return "canonical_artifact_checksum_mismatch"
+        if legacy_match is not None and not checksum.startswith(legacy_match.group(1)):
+            return "legacy_artifact_checksum_mismatch"
+        if artifact.get("content_identity") != {"algorithm": "sha256", "value": checksum}:
+            return "artifact_content_identity_mismatch"
+        if artifact.get("original_storage_ref") != f"sha256:{checksum}":
+            return "artifact_original_storage_ref_mismatch"
+        if not isinstance(expected_size, int) or isinstance(expected_size, bool) or expected_size < 0:
+            return "artifact_original_size_invalid"
+        return None
+
+    def get_artifact(self, artifact_id: str, scope: dict[str, str] | None = None) -> dict[str, Any] | None:
+        try:
+            artifact = self._get_artifact_unchecked(artifact_id, scope)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if artifact is None or self._artifact_identity_error(artifact, artifact_id, scope) is not None:
+            return None
+        return artifact
+
+    def _load_search_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
         path = self.search_snapshot_path(snapshot_id)
         if not path.exists():
             return None
         return _read_json(path)
+
+    def _search_snapshot_identity_error(self, snapshot: dict[str, Any], snapshot_id: str) -> str | None:
+        if snapshot.get("search_snapshot_id") != snapshot_id:
+            return "search_snapshot_id_mismatch"
+        if not _short_content_address_matches(
+            snapshot,
+            id_key="search_snapshot_id",
+            prefix="search_",
+        ):
+            return "search_snapshot_record_changed"
+        revision = str(snapshot.get("result_revision_sha256") or "")
+        if not re.fullmatch(r"[0-9a-f]{64}", revision) or revision != _search_result_revision_sha256(snapshot):
+            return "search_snapshot_result_revision_missing_or_changed"
+        return None
+
+    def get_search_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
+        try:
+            snapshot = self._load_search_snapshot(snapshot_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if snapshot is None or self._search_snapshot_identity_error(snapshot, snapshot_id) is not None:
+            return None
+        return snapshot
 
     def read_search_snapshot(
         self,
@@ -1300,11 +1434,25 @@ class LocalRuntimeStore:
         *,
         reason: str,
     ) -> dict[str, Any]:
-        snapshot = self.get_search_snapshot(snapshot_id)
+        try:
+            snapshot = self._load_search_snapshot(snapshot_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return {
+                "status": "integrity_failed",
+                "record_kind": "search_snapshot",
+                "reason": "search_snapshot_record_unreadable",
+            }
         if snapshot is None:
             return {"status": "not_found", "record_kind": "search_snapshot"}
         if snapshot.get("filters") != scope:
             return {"status": "scope_denied", "resource_scope": snapshot.get("filters")}
+        identity_error = self._search_snapshot_identity_error(snapshot, snapshot_id)
+        if identity_error is not None:
+            return {
+                "status": "integrity_failed",
+                "record_kind": "search_snapshot",
+                "reason": identity_error,
+            }
         event = self.append_audit(
             "search.snapshot.read",
             scope,
@@ -1317,11 +1465,34 @@ class LocalRuntimeStore:
         )
         return {"snapshot": snapshot, "audit_event": event}
 
-    def get_evidence_bundle(self, bundle_id: str) -> dict[str, Any] | None:
+    def _load_evidence_bundle(self, bundle_id: str) -> dict[str, Any] | None:
         path = self.evidence_bundle_path(bundle_id)
         if not path.exists():
             return None
         return _read_json(path)
+
+    def _evidence_bundle_identity_error(self, bundle: dict[str, Any], bundle_id: str) -> str | None:
+        if bundle.get("evidence_bundle_id") != bundle_id:
+            return "evidence_bundle_id_mismatch"
+        if not _short_content_address_matches(
+            bundle,
+            id_key="evidence_bundle_id",
+            prefix="evb_",
+        ):
+            return "evidence_bundle_record_changed"
+        revision = str(bundle.get("evidence_revision_sha256") or "")
+        if not re.fullmatch(r"[0-9a-f]{64}", revision) or revision != _evidence_bundle_revision_sha256(bundle):
+            return "evidence_bundle_revision_changed"
+        return None
+
+    def get_evidence_bundle(self, bundle_id: str) -> dict[str, Any] | None:
+        try:
+            bundle = self._load_evidence_bundle(bundle_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if bundle is None or self._evidence_bundle_identity_error(bundle, bundle_id) is not None:
+            return None
+        return bundle
 
     def get_evidence_chunk(self, chunk_id: str) -> dict[str, Any] | None:
         try:
@@ -1331,33 +1502,420 @@ class LocalRuntimeStore:
         if not path.exists():
             return None
         try:
-            return _read_json(path)
+            chunk = _read_json(path)
         except (OSError, ValueError, json.JSONDecodeError):
             return None
+        if not isinstance(chunk, dict) or chunk.get("evidence_chunk_id") != chunk_id:
+            return None
+        # Legacy 16-hex chunk IDs were mutable path labels. They remain
+        # display-only historical data and cannot enter citation authority.
+        if not re.fullmatch(r"chunk_[0-9a-f]{64}", chunk_id):
+            return None
+        chunk_base = deepcopy(chunk)
+        chunk_base.pop("evidence_chunk_id", None)
+        evidence_refs = chunk_base.get("evidence_refs")
+        if not isinstance(evidence_refs, list):
+            return None
+        self_ref = f"evidence_chunk:{chunk_id}"
+        chunk_base["evidence_refs"] = [ref for ref in evidence_refs if ref != self_ref]
+        if f"chunk_{_json_hash(chunk_base)}" != chunk_id:
+            return None
+        return chunk
 
     def get_citation_check(self, check_id: str) -> dict[str, Any] | None:
-        path = self.citation_check_path(check_id)
+        try:
+            path = self.citation_check_path(check_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            check = _read_json(path)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if check.get("citation_check_id") != check_id:
+            return None
+        if not _short_content_address_matches(check, id_key="citation_check_id", prefix="citecheck_"):
+            return None
+        return check
+
+    def _claim_record_identity_error(self, claim: dict[str, Any]) -> str | None:
+        claim_id = str(claim.get("claim_id") or "")
+        if not re.fullmatch(r"claim_[0-9a-f]{16}", claim_id):
+            return None
+        normalized: dict[str, Any] = {}
+        if "activity_refs" in claim:
+            normalized["activity_refs"] = []
+        if "audit_refs" in claim:
+            normalized["audit_refs"] = []
+        if not _short_content_address_matches(
+            claim,
+            id_key="claim_id",
+            prefix="claim_",
+            normalized_fields=normalized,
+        ):
+            return "claim_record_changed"
+        return None
+
+    def _brief_record_identity_error(self, brief: dict[str, Any]) -> str | None:
+        brief_id = str(brief.get("brief_id") or "")
+        if not re.fullmatch(r"brief_[0-9a-f]{16}", brief_id):
+            if (
+                brief.get("presented_as_fact") is True
+                or str(brief.get("trust_label") or "").lower()
+                in {"evidence_backed", "corroborated"}
+            ):
+                return "authoritative_brief_id_not_content_addressed"
+            return None
+        normalized = {"audit_refs": []} if "audit_refs" in brief else {}
+        if not _short_content_address_matches(
+            brief,
+            id_key="brief_id",
+            prefix="brief_",
+            normalized_fields=normalized,
+        ):
+            return "brief_record_changed"
+        return None
+
+    def _citation_set_integrity(
+        self,
+        *,
+        citation_refs: Any,
+        citation_check_refs: Any,
+        scope: dict[str, str],
+        output_kind: str,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        if not isinstance(citation_refs, list) or not citation_refs or not all(
+            isinstance(ref, str) for ref in citation_refs
+        ):
+            return [], "citation_refs_missing_or_invalid"
+        if not isinstance(citation_check_refs, list) or not citation_check_refs or not all(
+            isinstance(ref, str) for ref in citation_check_refs
+        ):
+            return [], "citation_check_refs_missing_or_invalid"
+
+        chunks: list[dict[str, Any]] = []
+        for ref in sorted(set(citation_refs)):
+            _, chunk, error_code = self._validate_citation_ref(ref, scope)
+            if error_code is not None or chunk is None:
+                return [], f"citation_ref_not_current:{error_code or 'unresolved'}"
+            chunks.append(chunk)
+
+        checked_refs: set[str] = set()
+        for ref in citation_check_refs:
+            if not ref.startswith("citation_check:"):
+                return [], "citation_check_ref_invalid"
+            check = self.get_citation_check(ref.split(":", 1)[1])
+            if (
+                check is None
+                or check.get("scope") != scope
+                or check.get("output_kind") != output_kind
+                or check.get("status") != "passed"
+                or not isinstance(check.get("citation_refs"), list)
+            ):
+                return [], "citation_check_missing_or_changed"
+            checked_refs.update(str(value) for value in check["citation_refs"] if isinstance(value, str))
+        if checked_refs != set(citation_refs):
+            return [], "citation_check_binding_mismatch"
+        return chunks, None
+
+    def _effective_claim_record(self, stored: dict[str, Any]) -> dict[str, Any]:
+        """Project stored Claims through the current semantic-authority ceiling.
+
+        Option 1 intentionally introduces no semantic-attestation Interface.
+        Therefore no legacy or manually edited record can earn authority from a
+        lexical support flag or a bare boolean.
+        """
+
+        claim = deepcopy(stored)
+        recorded_status = claim.get("status")
+        recorded_trust_state = claim.get("trust_state")
+        recorded_authority = deepcopy(claim.get("authority")) if isinstance(claim.get("authority"), dict) else {}
+        invalid_support_shape = "statement_support" in claim and not isinstance(claim.get("statement_support"), dict)
+        support = claim.get("statement_support") if isinstance(claim.get("statement_support"), dict) else {} if invalid_support_shape else None
+        canonical_claim_id = bool(re.fullmatch(r"claim_[0-9a-f]{16}", str(claim.get("claim_id") or "")))
+        legacy_support_unverified = bool(
+            support is not None
+            and not canonical_claim_id
+            and support.get("status") in {"passed", "source_supported"}
+        )
+        evidence = claim.get("evidence_bundle") if isinstance(claim.get("evidence_bundle"), dict) else {}
+        bundle_id = str(evidence.get("evidence_bundle_id") or "")
+        artifact_refs = evidence.get("artifact_refs") if isinstance(evidence.get("artifact_refs"), list) else []
+        evidence_item_count = evidence.get("evidence_item_count")
+        has_evidence = bool(
+            bundle_id
+            and isinstance(evidence_item_count, int)
+            and evidence_item_count > 0
+            and artifact_refs
+        )
+        record_identity_error = self._claim_record_identity_error(claim)
+        integrity_error: dict[str, Any] | None = (
+            {"status": "integrity_failed", "reason": record_identity_error}
+            if record_identity_error is not None
+            else {"status": "integrity_failed", "reason": "claim_statement_support_invalid"}
+            if invalid_support_shape
+            else None
+        )
+        if has_evidence and integrity_error is None:
+            bundle = self.get_evidence_bundle(bundle_id)
+            if bundle is None:
+                integrity_error = {
+                    "status": "integrity_failed",
+                    "reason": "claim_evidence_bundle_missing_or_changed",
+                }
+            else:
+                _, integrity_error = self._validated_evidence_bundle_items(
+                    bundle,
+                    claim.get("scope") if isinstance(claim.get("scope"), dict) else {},
+                )
+                expected_bindings = (
+                    evidence.get("representation_bindings")
+                    if isinstance(evidence.get("representation_bindings"), list)
+                    else []
+                )
+                current_bindings = [
+                    {
+                        "artifact_id": item.get("artifact_id"),
+                        "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                        "derived_representation_id": item.get("derived_representation_id"),
+                        "derived_representation_ref": item.get("derived_representation_ref"),
+                        "derived_content_sha256": item.get("derived_content_sha256"),
+                        "derived_content_size_bytes": item.get("derived_content_size_bytes"),
+                    }
+                    for item in bundle.get("evidence_items", [])
+                    if isinstance(item, dict)
+                ]
+                if integrity_error is None and (
+                    evidence.get("evidence_revision_sha256") != bundle.get("evidence_revision_sha256")
+                    or expected_bindings != current_bindings
+                ):
+                    integrity_error = {
+                        "status": "integrity_failed",
+                        "reason": "claim_evidence_revision_missing_or_changed",
+                    }
+        if (
+            integrity_error is None
+            and support is not None
+            and not legacy_support_unverified
+            and support.get("status") in {"passed", "source_supported"}
+        ):
+            statement = str(claim.get("statement") or "")
+            if support.get("statement_sha256") != _claim_statement_sha256(statement):
+                integrity_error = {
+                    "status": "integrity_failed",
+                    "reason": "claim_statement_support_missing_or_changed",
+                }
+            else:
+                chunks, citation_error = self._citation_set_integrity(
+                    citation_refs=support.get("citation_refs"),
+                    citation_check_refs=support.get("citation_check_refs"),
+                    scope=claim.get("scope") if isinstance(claim.get("scope"), dict) else {},
+                    output_kind="claim_statement",
+                )
+                anchor = _statement_source_anchor(
+                    statement,
+                    [str(chunk.get("text") or "") for chunk in chunks],
+                ) if citation_error is None else {"status": "failed"}
+                if citation_error is not None or anchor.get("status") != "passed":
+                    integrity_error = {
+                        "status": "integrity_failed",
+                        "reason": citation_error or "claim_statement_anchor_changed",
+                    }
+        if support is not None:
+            if legacy_support_unverified:
+                support["status"] = "not_verified"
+                support["statement_support_state"] = "not_verified"
+                support["source_support_state"] = "not_verified"
+                support["citation_integrity_state"] = "not_verified"
+                support["citations_bound_to_evidence_revision"] = False
+            elif support.get("status") == "passed":
+                support["status"] = "source_supported"
+            if support.get("statement_support_state") == "deterministic_anchor_passed":
+                support["statement_support_state"] = "source_supported"
+            if support.get("status") == "source_supported":
+                support["source_support_state"] = "passed"
+            if integrity_error is not None:
+                support["status"] = "integrity_failed"
+                support["statement_support_state"] = "integrity_failed"
+                support["source_support_state"] = "failed"
+                support["citation_integrity_state"] = "failed"
+                support["citations_bound_to_evidence_revision"] = False
+                support["semantic_faithfulness_state"] = "not_verified"
+                support["integrity_error"] = integrity_error.get("reason")
+            else:
+                support["semantic_faithfulness_state"] = "human_required"
+            support["semantic_support_verified"] = False
+            support["semantic_review_required"] = True
+            support["approval_eligible"] = False
+            claim["statement_support"] = support
+        claim["status"] = "draft"
+        claim["trust_state"] = "draft"
+        blocked_reason = (
+            "Evidence Bundle is required before this Claim can gain authority."
+            if not has_evidence
+            else "The Claim evidence chain failed integrity verification and must be repaired before review."
+            if integrity_error is not None
+            else "Statement-level semantic support is required before this Claim can gain authority."
+            if support is not None and support.get("status") == "source_supported"
+            else "The exact Claim statement needs current source support before semantic review and owner approval."
+        )
+        claim["authority"] = {
+            "can_be_approved": False,
+            "can_publish_shared_truth": False,
+            "can_drive_autonomous_action": False,
+            "blocked_reason": blocked_reason,
+        }
+        claim["evidence_integrity"] = {
+            "status": "failed" if integrity_error is not None else "passed" if has_evidence else "not_attached",
+            "reason": integrity_error.get("reason") if integrity_error is not None else None,
+        }
+        if (
+            recorded_status != "draft"
+            or recorded_trust_state != "draft"
+            or any(recorded_authority.get(key) is True for key in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action"))
+        ):
+            claim["effective_authority_migration"] = {
+                "recorded_status": recorded_status,
+                "recorded_trust_state": recorded_trust_state,
+                "recorded_authority": recorded_authority,
+                "effective_status": "draft",
+                "effective_trust_state": "draft",
+                "reason": "legacy_claim_lacks_statement_level_semantic_attestation",
+                "persisted_record_mutated": False,
+            }
+        return claim
+
+    def _effective_brief_record(self, stored: dict[str, Any]) -> dict[str, Any]:
+        brief = deepcopy(stored)
+        evidence = brief.get("evidence_bundle") if isinstance(brief.get("evidence_bundle"), dict) else {}
+        bundle_id = str(evidence.get("evidence_bundle_id") or "")
+        record_identity_error = self._brief_record_identity_error(brief)
+        integrity_error: dict[str, Any] | None = (
+            {"reason": record_identity_error} if record_identity_error is not None else None
+        )
+        if not bundle_id:
+            brief["evidence_integrity"] = {"status": "not_attached", "reason": None}
+            if integrity_error is None and brief.get("presented_as_fact") is not True and str(brief.get("trust_label") or "").lower() not in {
+                "evidence_backed",
+                "corroborated",
+            }:
+                return brief
+            integrity_error = {"reason": "brief_evidence_bundle_missing"}
+        elif integrity_error is None:
+            bundle = self.get_evidence_bundle(bundle_id)
+            if bundle is None:
+                integrity_error = {"reason": "brief_evidence_bundle_missing_or_changed"}
+            else:
+                _, integrity_error = self._validated_evidence_bundle_items(
+                    bundle,
+                    brief.get("scope") if isinstance(brief.get("scope"), dict) else {},
+                )
+                if (
+                    integrity_error is None
+                    and evidence.get("evidence_revision_sha256") != bundle.get("evidence_revision_sha256")
+                ):
+                    integrity_error = {"reason": "brief_evidence_revision_missing_or_changed"}
+        evidence_backed = bool(
+            str(brief.get("trust_label") or "").lower() in {"evidence_backed", "corroborated"}
+            or brief.get("presented_as_fact") is True
+        )
+        if integrity_error is None and evidence_backed:
+            chunks, citation_error = self._citation_set_integrity(
+                citation_refs=brief.get("citation_refs"),
+                citation_check_refs=brief.get("citation_check_refs"),
+                scope=brief.get("scope") if isinstance(brief.get("scope"), dict) else {},
+                output_kind="brief",
+            )
+            rows = brief.get("key_point_citations")
+            key_points = brief.get("key_points")
+            if citation_error is not None:
+                integrity_error = {"reason": citation_error}
+            elif (
+                not isinstance(rows, list)
+                or not isinstance(key_points, list)
+                or [row.get("statement") for row in rows if isinstance(row, dict)] != key_points
+            ):
+                integrity_error = {"reason": "brief_key_point_binding_missing_or_changed"}
+            else:
+                chunks_by_ref = {
+                    f"evidence_chunk:{chunk.get('evidence_chunk_id')}": chunk
+                    for chunk in chunks
+                }
+                for row in rows:
+                    row_refs = row.get("citation_refs") if isinstance(row, dict) else None
+                    if not isinstance(row_refs, list) or not row_refs:
+                        integrity_error = {"reason": "brief_key_point_citation_missing"}
+                        break
+                    anchor = _statement_source_anchor(
+                        str(row.get("statement") or ""),
+                        [
+                            str(chunks_by_ref[ref].get("text") or "")
+                            for ref in row_refs
+                            if ref in chunks_by_ref
+                        ],
+                    )
+                    if anchor.get("status") != "passed":
+                        integrity_error = {"reason": "brief_key_point_anchor_changed"}
+                        break
+        if integrity_error is None:
+            brief["evidence_integrity"] = {"status": "passed", "reason": None}
+            return brief
+
+        brief["status"] = "integrity_failed"
+        brief["trust_label"] = "draft"
+        brief["presented_as_fact"] = False
+        label_check = deepcopy(brief.get("label_check")) if isinstance(brief.get("label_check"), dict) else {}
+        label_check["earned_evidence_backed"] = False
+        label_check["integrity_failed"] = True
+        brief["label_check"] = label_check
+        brief["evidence_integrity"] = {
+            "status": "failed",
+            "reason": integrity_error.get("reason"),
+        }
+        return brief
 
     def get_claim(self, claim_id: str) -> dict[str, Any] | None:
-        path = self.claim_path(claim_id)
+        try:
+            path = self.claim_path(claim_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            stored = _read_json(path)
+            if stored.get("claim_id") != claim_id:
+                return None
+            return self._effective_claim_record(stored)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def get_brief(self, brief_id: str) -> dict[str, Any] | None:
-        path = self.brief_path(brief_id)
+        try:
+            path = self.brief_path(brief_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            stored = _read_json(path)
+            if stored.get("brief_id") != brief_id:
+                return None
+            return self._effective_brief_record(stored)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def get_conversation(self, conversation_id: str) -> dict[str, Any] | None:
-        path = self.conversation_path(conversation_id)
+        try:
+            path = self.conversation_path(conversation_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            return _read_json(path)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def conversation_source_safety(self, conversation: dict[str, Any], scope: dict[str, str]) -> dict[str, Any]:
         safety = conversation.get("safety")
@@ -1369,16 +1927,29 @@ class LocalRuntimeStore:
         return artifact_safety if isinstance(artifact_safety, dict) else {}
 
     def get_mission(self, mission_id: str) -> dict[str, Any] | None:
-        path = self.mission_path(mission_id)
+        try:
+            path = self.mission_path(mission_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            return _read_json(path)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def get_action(self, action_id: str) -> dict[str, Any] | None:
-        path = self.action_path(action_id)
+        try:
+            path = self.action_path(action_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            action = _read_json(path)
+            return action if action.get("action_id") == action_id else None
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def get_agent_role(self, role_id: str) -> dict[str, Any] | None:
         path = self.agent_role_path(role_id)
@@ -1402,10 +1973,17 @@ class LocalRuntimeStore:
         return _read_json(path)
 
     def get_memory(self, memory_id: str) -> dict[str, Any] | None:
-        path = self.memory_path(memory_id)
+        try:
+            path = self.memory_path(memory_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
-        return _read_json(path)
+        try:
+            memory = _read_json(path)
+            return memory if memory.get("memory_id") == memory_id else None
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     def get_memory_conflict(self, conflict_id: str) -> dict[str, Any] | None:
         path = self.memory_conflict_path(conflict_id)
@@ -1600,7 +2178,7 @@ class LocalRuntimeStore:
             return []
         records = []
         for path in sorted(claim_dir.glob("*.json")):
-            record = _read_json(path)
+            record = self._effective_claim_record(_read_json(path))
             if record.get("scope") == scope:
                 records.append(record)
         return records
@@ -1611,7 +2189,7 @@ class LocalRuntimeStore:
             return []
         records = []
         for path in sorted(brief_dir.glob("*.json")):
-            record = _read_json(path)
+            record = self._effective_brief_record(_read_json(path))
             if record.get("scope") == scope:
                 records.append(record)
         return records
@@ -5279,7 +5857,7 @@ class LocalRuntimeStore:
                     kind="claim",
                     ref=f"claim:{claim_id}" if claim_id else None,
                     record=records.get("claim"),
-                    description="Keep the claim candidate evidence-backed before approval.",
+                    description="Keep the Claim as a Draft until source support and statement-level semantic review are complete.",
                     continue_target="#claim-builder",
                 ),
                 _stage_row(
@@ -6422,21 +7000,82 @@ class LocalRuntimeStore:
         snapshot_id = evidence.get("search_snapshot_id")
         bundle = self.get_evidence_bundle(bundle_id) if bundle_id else None
         snapshot = self.get_search_snapshot(snapshot_id) if snapshot_id else None
+        if not isinstance(bundle, dict):
+            return {
+                "status": "integrity_failed",
+                "claim_id": claim_id,
+                "reason": "claim_basis_evidence_bundle_missing_or_changed",
+            }
+        resolved_items, integrity_error = self._validated_evidence_bundle_items(bundle, scope)
+        if integrity_error is not None:
+            return {
+                **integrity_error,
+                "claim_id": claim_id,
+            }
+        expected_bindings = evidence.get("representation_bindings") if isinstance(evidence.get("representation_bindings"), list) else []
+        current_bindings = [
+            {
+                "artifact_id": item.get("artifact_id"),
+                "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                "derived_representation_id": item.get("derived_representation_id"),
+                "derived_representation_ref": item.get("derived_representation_ref"),
+                "derived_content_sha256": item.get("derived_content_sha256"),
+                "derived_content_size_bytes": item.get("derived_content_size_bytes"),
+            }
+            for item in (bundle.get("evidence_items", []) if isinstance(bundle, dict) else [])
+            if isinstance(item, dict)
+        ]
+        lineage_current = bool(
+            snapshot
+            and bundle.get("evidence_revision_sha256") == evidence.get("evidence_revision_sha256")
+            and bundle.get("search_result_revision_sha256") == snapshot.get("result_revision_sha256")
+            and expected_bindings == current_bindings
+        )
+        if not lineage_current:
+            return {
+                "status": "integrity_failed",
+                "claim_id": claim_id,
+                "reason": "claim_basis_evidence_revision_missing_or_changed",
+            }
         artifact_records = []
+        resolved_by_artifact = {
+            str(resolved["item"].get("artifact_id") or ""): resolved
+            for resolved in resolved_items
+        }
         for artifact_ref in evidence.get("artifact_refs", []):
             artifact_id = str(artifact_ref).split("artifact:", 1)[-1]
-            artifact = self.get_artifact(artifact_id, scope)
-            if artifact is not None:
-                artifact_records.append(
-                    {
-                        "artifact_id": artifact_id,
-                        "scope": artifact.get("scope"),
-                        "source": artifact.get("source"),
-                        "original_storage_ref": artifact.get("original_storage_ref"),
-                        "derived_text_ref": artifact.get("derived", {}).get("text_ref"),
-                        "provenance": artifact.get("provenance"),
-                    }
-                )
+            resolved = resolved_by_artifact.get(artifact_id)
+            if resolved is None:
+                return {
+                    "status": "integrity_failed",
+                    "artifact_id": artifact_id,
+                    "reason": "claim_basis_representation_binding_missing_or_changed",
+                }
+            binding = resolved["item"]
+            artifact_records.append(
+                {
+                    "artifact_id": artifact_id,
+                    "scope": binding.get("scope", scope),
+                    "source": binding.get("source"),
+                    "original_storage_ref": binding.get("original_storage_ref"),
+                    "original_checksum_sha256": binding.get("artifact_checksum_sha256"),
+                    "original_size_bytes": binding.get(
+                        "original_size_bytes",
+                        resolved["artifact"].get("original_size_bytes"),
+                    ),
+                    "media_type": binding.get("media_type", resolved["artifact"].get("media_type")),
+                    "raw_original_access": binding.get(
+                        "raw_original_access",
+                        resolved["artifact"].get("raw_original_access"),
+                    ),
+                    "derived_text_ref": binding.get("derived_storage_ref"),
+                    "derived_representation_id": binding.get("derived_representation_id"),
+                    "derived_representation_ref": binding.get("derived_representation_ref"),
+                    "derived_content_sha256": binding.get("derived_content_sha256"),
+                    "derived_content_size_bytes": binding.get("derived_content_size_bytes"),
+                    "provenance": binding.get("provenance"),
+                }
+            )
 
         audit_events = [
             event
@@ -6463,6 +7102,8 @@ class LocalRuntimeStore:
                 "evidence_bundle_id": bundle_id,
                 "evidence_item_count": len(bundle.get("evidence_items", [])) if bundle else 0,
                 "artifact_refs": evidence.get("artifact_refs", []),
+                "derived_representation_refs": evidence.get("derived_representation_refs", []),
+                "evidence_revision_sha256": evidence.get("evidence_revision_sha256"),
             },
             "transformations": [
                 {
@@ -6470,6 +7111,8 @@ class LocalRuntimeStore:
                     "status": "preserved",
                     "artifact_id": artifact["artifact_id"],
                     "derived_text_ref": artifact.get("derived_text_ref"),
+                    "derived_representation_ref": artifact.get("derived_representation_ref"),
+                    "derived_content_sha256": artifact.get("derived_content_sha256"),
                 }
                 for artifact in artifact_records
             ],
@@ -6488,7 +7131,11 @@ class LocalRuntimeStore:
             "freshness": {
                 "status": "current",
                 "validity_state": "inspectable",
-                "reproducible_from_archive": bool(bundle and snapshot and artifact_records),
+                "reproducible_from_archive": bool(
+                    snapshot
+                    and artifact_records
+                    and len(artifact_records) == len(evidence.get("artifact_refs", []))
+                ),
             },
             "created_at": utc_now(),
         }
@@ -7985,40 +8632,304 @@ class LocalRuntimeStore:
         )
         return {"experience_export": export, "audit_event": event}
 
-    def _derived_text_path(self, artifact: dict[str, Any]) -> Path | None:
-        text_ref = artifact.get("derived", {}).get("text_ref")
-        if not text_ref:
+    def _derived_representation_identity(
+        self,
+        *,
+        artifact_id: str,
+        artifact_checksum_sha256: str,
+        content_checksum_sha256: str,
+    ) -> str:
+        identity = {
+            "artifact_id": artifact_id,
+            "artifact_checksum_sha256": artifact_checksum_sha256,
+            "content_checksum_sha256": content_checksum_sha256,
+            "representation_type": DERIVED_REPRESENTATION_TYPE,
+            "extractor": DERIVED_EXTRACTOR,
+            "extractor_version": DERIVED_EXTRACTOR_VERSION,
+        }
+        return f"drv_{_json_hash(identity)}"
+
+    def _create_derived_representation(
+        self,
+        *,
+        artifact_id: str,
+        artifact_checksum_sha256: str,
+        text: str,
+        redacted: bool,
+    ) -> dict[str, Any]:
+        content = text.encode("utf-8")
+        content_checksum = sha256_bytes(content)
+        representation_id = self._derived_representation_identity(
+            artifact_id=artifact_id,
+            artifact_checksum_sha256=artifact_checksum_sha256,
+            content_checksum_sha256=content_checksum,
+        )
+        storage_ref = f"derived/content/sha256/{content_checksum}.txt"
+        content_path = self.artifact_dir / storage_ref
+        store_content_atomically(content_path, content, checksum_sha256=content_checksum)
+
+        record_path = self.derived_representation_path(representation_id)
+        expected_identity = {
+            "schema_version": "cs.derived_representation.v1",
+            "derived_representation_id": representation_id,
+            "artifact_id": artifact_id,
+            "artifact_checksum_sha256": artifact_checksum_sha256,
+            "content_checksum_sha256": content_checksum,
+            "content_size_bytes": len(content),
+            "representation_type": DERIVED_REPRESENTATION_TYPE,
+            "extractor": DERIVED_EXTRACTOR,
+            "extractor_version": DERIVED_EXTRACTOR_VERSION,
+            "storage_ref": storage_ref,
+            "status": "ready",
+            "media_type": "text/plain",
+            "redacted": redacted,
+        }
+        existing: dict[str, Any] | None = None
+        if record_path.is_file() and not record_path.is_symlink():
+            try:
+                candidate = _read_json(record_path)
+            except (OSError, ValueError, TypeError):
+                candidate = {}
+            if all(candidate.get(key) == value for key, value in expected_identity.items()):
+                existing = candidate
+        if existing is not None:
+            record = existing
+        else:
+            record = {
+                **expected_identity,
+                "created_at": utc_now(),
+            }
+            encoded = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode("utf-8")
+            store_content_atomically(
+                record_path,
+                encoded,
+                checksum_sha256=sha256_bytes(encoded),
+            )
+        return {
+            "status": "ready",
+            "media_type": "text/plain",
+            "text_ref": storage_ref,
+            "storage_ref": storage_ref,
+            "derived_representation_id": representation_id,
+            "representation_ref": f"derived_representation:{representation_id}",
+            "derived_representation_ref": f"derived_representation:{representation_id}",
+            "artifact_checksum_sha256": artifact_checksum_sha256,
+            "content_checksum_sha256": content_checksum,
+            "content_size_bytes": len(content),
+            "representation_type": DERIVED_REPRESENTATION_TYPE,
+            "extractor": DERIVED_EXTRACTOR,
+            "extractor_version": DERIVED_EXTRACTOR_VERSION,
+            "redacted": redacted,
+        }
+
+    def _legacy_derived_representation(
+        self,
+        artifact: dict[str, Any],
+    ) -> tuple[dict[str, Any], Path] | None:
+        derived = artifact.get("derived") if isinstance(artifact.get("derived"), dict) else {}
+        text_ref = str(derived.get("text_ref") or "")
+        checksum = str(artifact.get("checksum_sha256") or "")
+        if not text_ref or not re.fullmatch(r"[0-9a-f]{64}", checksum):
             return None
         root = self.artifact_dir.resolve()
-        path = (root / str(text_ref)).resolve()
-        if root not in path.parents or not path.is_file():
+        path = (root / text_ref).resolve()
+        if root not in path.parents or path.is_symlink() or not path.is_file():
             return None
-        return path
+        original = self._read_verified_original_bytes(artifact)
+        if original is None or not str(artifact.get("media_type") or "").startswith("text/"):
+            return None
+        expected_text = redact_text(original.decode("utf-8", errors="replace"))
+        expected_content = expected_text.encode("utf-8")
+        content_checksum = sha256_bytes(expected_content)
+        if not verify_content_file(
+            path,
+            checksum_sha256=content_checksum,
+            size_bytes=len(expected_content),
+        ):
+            return None
+        representation_id = self._derived_representation_identity(
+            artifact_id=str(artifact.get("artifact_id") or ""),
+            artifact_checksum_sha256=checksum,
+            content_checksum_sha256=content_checksum,
+        )
+        return (
+            {
+                "schema_version": "cs.derived_representation.legacy.v1",
+                "derived_representation_id": representation_id,
+                "artifact_id": artifact.get("artifact_id"),
+                "artifact_checksum_sha256": checksum,
+                "content_checksum_sha256": content_checksum,
+                "content_size_bytes": len(expected_content),
+                "representation_type": DERIVED_REPRESENTATION_TYPE,
+                "extractor": DERIVED_EXTRACTOR,
+                "extractor_version": "legacy-verified",
+                "storage_ref": text_ref,
+                "status": "ready",
+                "media_type": "text/plain",
+                "redacted": expected_text != original.decode("utf-8", errors="replace"),
+                "created_at": artifact.get("provenance", {}).get("created_at"),
+            },
+            path,
+        )
+
+    def _resolved_derived_representation(
+        self,
+        artifact: dict[str, Any],
+        *,
+        expected: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], Path] | None:
+        derived = artifact.get("derived") if isinstance(artifact.get("derived"), dict) else {}
+        expected_representation_id = str((expected or {}).get("derived_representation_id") or "")
+        representation_id = expected_representation_id or str(derived.get("derived_representation_id") or "")
+        resolved: tuple[dict[str, Any], Path] | None = None
+        if representation_id:
+            try:
+                record = _read_json(self.derived_representation_path(representation_id))
+            except (OSError, ValueError, TypeError):
+                record = {}
+            checksum = str(record.get("content_checksum_sha256") or "")
+            size_bytes = record.get("content_size_bytes")
+            artifact_checksum = str(artifact.get("checksum_sha256") or "")
+            storage_ref = str(record.get("storage_ref") or "")
+            canonical_storage_ref = f"derived/content/sha256/{checksum}.txt"
+            calculated_representation_id = (
+                self._derived_representation_identity(
+                    artifact_id=str(artifact.get("artifact_id") or ""),
+                    artifact_checksum_sha256=artifact_checksum,
+                    content_checksum_sha256=checksum,
+                )
+                if re.fullmatch(r"[0-9a-f]{64}", artifact_checksum)
+                and re.fullmatch(r"[0-9a-f]{64}", checksum)
+                else ""
+            )
+            identity_matches = bool(
+                record.get("schema_version") == "cs.derived_representation.v1"
+                and record.get("status") == "ready"
+                and record.get("derived_representation_id") == representation_id
+                and calculated_representation_id == representation_id
+                and record.get("artifact_id") == artifact.get("artifact_id")
+                and record.get("artifact_checksum_sha256") == artifact_checksum
+                and record.get("representation_type") == DERIVED_REPRESENTATION_TYPE
+                and record.get("extractor") == DERIVED_EXTRACTOR
+                and record.get("extractor_version") == DERIVED_EXTRACTOR_VERSION
+                and record.get("media_type") == "text/plain"
+                and isinstance(record.get("redacted"), bool)
+                and re.fullmatch(r"[0-9a-f]{64}", checksum)
+                and isinstance(size_bytes, int)
+                and size_bytes >= 0
+                and storage_ref == canonical_storage_ref
+            )
+            if identity_matches and not expected_representation_id:
+                identity_matches = bool(
+                    derived.get("content_checksum_sha256") == checksum
+                    and derived.get("content_size_bytes") == size_bytes
+                    and (derived.get("storage_ref") or derived.get("text_ref")) == storage_ref
+                )
+            path = self.artifact_dir / canonical_storage_ref
+            if identity_matches and verify_content_file(
+                path,
+                checksum_sha256=checksum,
+                size_bytes=int(size_bytes),
+            ):
+                resolved = (record, path)
+        elif not expected_representation_id:
+            resolved = self._legacy_derived_representation(artifact)
+
+        if resolved is None:
+            return None
+        record, path = resolved
+        if expected:
+            expected_fields = {
+                "derived_representation_id": expected.get("derived_representation_id"),
+                "artifact_checksum_sha256": expected.get("artifact_checksum_sha256"),
+                "content_checksum_sha256": expected.get("derived_content_sha256")
+                or expected.get("content_checksum_sha256"),
+                "content_size_bytes": expected.get("derived_content_size_bytes")
+                if "derived_content_size_bytes" in expected
+                else expected.get("content_size_bytes"),
+                "storage_ref": expected.get("derived_storage_ref") or expected.get("storage_ref"),
+            }
+            for key, value in expected_fields.items():
+                if value is not None and record.get(key) != value:
+                    return None
+        return record, path
+
+    def _derived_representation_binding(self, artifact: dict[str, Any]) -> dict[str, Any] | None:
+        resolved = self._resolved_derived_representation(artifact)
+        if resolved is None:
+            return None
+        record, _ = resolved
+        if record.get("schema_version") == "cs.derived_representation.legacy.v1":
+            derived = self._create_derived_representation(
+                artifact_id=str(artifact.get("artifact_id") or ""),
+                artifact_checksum_sha256=str(artifact.get("checksum_sha256") or ""),
+                text=self._derived_text(artifact),
+                redacted=bool(record.get("redacted")),
+            )
+            record = _read_json(
+                self.derived_representation_path(str(derived["derived_representation_id"]))
+            )
+        return {
+            "derived_representation_id": record["derived_representation_id"],
+            "derived_representation_ref": f"derived_representation:{record['derived_representation_id']}",
+            "artifact_checksum_sha256": record["artifact_checksum_sha256"],
+            "derived_content_sha256": record["content_checksum_sha256"],
+            "derived_content_size_bytes": record["content_size_bytes"],
+            "derived_storage_ref": record["storage_ref"],
+            "representation_type": record["representation_type"],
+            "extractor": record["extractor"],
+            "extractor_version": record["extractor_version"],
+        }
+
+    def _derived_text_path(self, artifact: dict[str, Any]) -> Path | None:
+        resolved = self._resolved_derived_representation(artifact)
+        return resolved[1] if resolved is not None else None
 
     def derived_text_available(self, artifact: dict[str, Any]) -> bool:
         return self._derived_text_path(artifact) is not None
 
+    def _read_resolved_derived_text(
+        self,
+        resolved: tuple[dict[str, Any], Path],
+    ) -> str | None:
+        record, path = resolved
+        content = read_verified_content_file(
+            path,
+            checksum_sha256=str(record.get("content_checksum_sha256") or ""),
+            size_bytes=int(record.get("content_size_bytes", -1)),
+        )
+        return content.decode("utf-8", errors="replace") if content is not None else None
+
     def _derived_text(self, artifact: dict[str, Any]) -> str:
-        path = self._derived_text_path(artifact)
-        if path is None:
+        resolved = self._resolved_derived_representation(artifact)
+        if resolved is None:
             return ""
-        return path.read_text(encoding="utf-8", errors="replace")
+        return self._read_resolved_derived_text(resolved) or ""
+
+    def _derived_text_from_binding(
+        self,
+        artifact: dict[str, Any],
+        binding: dict[str, Any],
+    ) -> str | None:
+        resolved = self._resolved_derived_representation(artifact, expected=binding)
+        if resolved is None:
+            return None
+        return self._read_resolved_derived_text(resolved)
 
     def derived_text_preview(self, artifact: dict[str, Any], limit: int = 500) -> str:
-        path = self._derived_text_path(artifact)
-        if path is None:
+        resolved = self._resolved_derived_representation(artifact)
+        if resolved is None:
             return ""
-        with path.open(encoding="utf-8", errors="replace") as handle:
-            return handle.read(max(0, limit)).replace("\n", " ").strip()
+        text = self._read_resolved_derived_text(resolved)
+        return (text or "")[: max(0, limit)].replace("\n", " ").strip()
 
     def derived_text_content(self, artifact: dict[str, Any], limit: int = 50_000) -> tuple[str, bool]:
         """Return a line-preserving source preview and whether it was truncated."""
 
-        path = self._derived_text_path(artifact)
-        if path is None:
+        resolved = self._resolved_derived_representation(artifact)
+        if resolved is None:
             return "", False
-        with path.open(encoding="utf-8", errors="replace") as handle:
-            text = handle.read(max(0, limit) + 1)
+        text = self._read_resolved_derived_text(resolved) or ""
         return text[:limit], len(text) > limit
 
     def _ontology_label_key(self, value: str) -> str:
@@ -8982,6 +9893,15 @@ class LocalRuntimeStore:
         return {"ontology_object": updated, "ontology_change_set": change_set, "audit_event": event}
 
     def _evidence_items_from_snapshot(self, snapshot: dict[str, Any], scope: dict[str, str]) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        stored_result_revision = str(snapshot.get("result_revision_sha256") or "")
+        if (
+            not re.fullmatch(r"[0-9a-f]{64}", stored_result_revision)
+            or stored_result_revision != _search_result_revision_sha256(snapshot)
+        ):
+            return [], {
+                "status": "integrity_failed",
+                "reason": "search_snapshot_result_revision_missing_or_changed",
+            }
         evidence_items = []
         for result in snapshot.get("results", []):
             artifact_id = result.get("artifact_id")
@@ -8994,7 +9914,13 @@ class LocalRuntimeStore:
                 return [], {"status": "scope_denied", "resource_scope": artifact.get("scope")}
             if not self.original_available(artifact):
                 return [], {"status": "integrity_failed", "artifact_id": artifact_id}
-            derived_text = self._derived_text(artifact)
+            derived_text = self._derived_text_from_binding(artifact, result)
+            if derived_text is None:
+                return [], {
+                    "status": "integrity_failed",
+                    "artifact_id": artifact_id,
+                    "reason": "derived_representation_missing_or_changed",
+                }
             snippet = result.get("snippet") or derived_text[:180].replace("\n", " ").strip()
             if not snippet:
                 continue
@@ -9002,9 +9928,22 @@ class LocalRuntimeStore:
                 {
                     "artifact_id": artifact["artifact_id"],
                     "search_snapshot_id": snapshot["search_snapshot_id"],
+                    "search_result_revision_sha256": snapshot.get("result_revision_sha256"),
                     "snippet": snippet,
                     "original_storage_ref": artifact.get("original_storage_ref"),
-                    "derived_text_ref": artifact.get("derived", {}).get("text_ref"),
+                    "derived_text_ref": result.get("derived_storage_ref") or result.get("derived_text_ref"),
+                    "derived_representation_id": result.get("derived_representation_id"),
+                    "derived_representation_ref": result.get("derived_representation_ref"),
+                    "artifact_checksum_sha256": result.get("artifact_checksum_sha256"),
+                    "derived_content_sha256": result.get("derived_content_sha256"),
+                    "derived_content_size_bytes": result.get("derived_content_size_bytes"),
+                    "derived_storage_ref": result.get("derived_storage_ref"),
+                    "representation_type": result.get("representation_type"),
+                    "extractor": result.get("extractor"),
+                    "extractor_version": result.get("extractor_version"),
+                    "media_type": artifact.get("media_type"),
+                    "raw_original_access": artifact.get("raw_original_access"),
+                    "original_size_bytes": artifact.get("original_size_bytes"),
                     "source": artifact.get("source"),
                     "provenance": artifact.get("provenance"),
                     "scope": scope,
@@ -9019,6 +9958,7 @@ class LocalRuntimeStore:
         *,
         query: str,
         evidence_bundle_id: str | None = None,
+        evidence_revision_sha256: str | None = None,
         model_provider: str = DEFAULT_MODEL_PROVIDER,
         embedding_model: str = DEFAULT_EMBEDDING_MODEL,
         ollama_base_url: str | None = None,
@@ -9043,7 +9983,26 @@ class LocalRuntimeStore:
             artifact = self.get_artifact(str(item.get("artifact_id")), scope)
             if artifact is None or artifact.get("scope") != scope:
                 continue
-            derived_text = self._derived_text(artifact)
+            if not self.original_available(artifact):
+                return {
+                    "status": "integrity_failed",
+                    "error": "Evidence Bundle references an unavailable original Artifact.",
+                    "artifact_id": item.get("artifact_id"),
+                    "chunks": [],
+                    "embedding_status": "not_requested",
+                    "embedding_model": embedding_model if use_embeddings else None,
+                }
+            derived_text = self._derived_text_from_binding(artifact, item)
+            if derived_text is None:
+                return {
+                    "status": "integrity_failed",
+                    "error": "Evidence Bundle references a missing or changed Derived Representation.",
+                    "artifact_id": item.get("artifact_id"),
+                    "chunks": [],
+                    "embedding_status": "not_requested",
+                    "embedding_model": embedding_model if use_embeddings else None,
+                }
+            chunk_evidence_revision = evidence_revision_sha256 or item.get("search_result_revision_sha256")
             for index, span in enumerate(_text_chunks(derived_text)):
                 text = str(span.get("text", ""))
                 if not text:
@@ -9073,6 +10032,7 @@ class LocalRuntimeStore:
                     "artifact_id": artifact["artifact_id"],
                     "artifact_ref": f"artifact:{artifact['artifact_id']}",
                     "evidence_bundle_id": evidence_bundle_id,
+                    "evidence_revision_sha256": chunk_evidence_revision,
                     "search_snapshot_id": item.get("search_snapshot_id"),
                     "span": {"char_start": span["char_start"], "char_end": span["char_end"]},
                     "text": text,
@@ -9080,7 +10040,13 @@ class LocalRuntimeStore:
                     "prompt_role": "quoted_evidence",
                     "untrusted_evidence": artifact.get("trust_state") == "untrusted",
                     "original_storage_ref": artifact.get("original_storage_ref"),
-                    "derived_text_ref": artifact.get("derived", {}).get("text_ref"),
+                    "derived_text_ref": item.get("derived_storage_ref") or item.get("derived_text_ref"),
+                    "derived_representation_id": item.get("derived_representation_id"),
+                    "derived_representation_ref": item.get("derived_representation_ref"),
+                    "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                    "derived_content_sha256": item.get("derived_content_sha256"),
+                    "derived_content_size_bytes": item.get("derived_content_size_bytes"),
+                    "derived_storage_ref": item.get("derived_storage_ref"),
                     "embedding": {
                         "model": embedding_model if use_embeddings else None,
                         "status": "embedded" if query_embedding is not None else "not_requested",
@@ -9088,15 +10054,25 @@ class LocalRuntimeStore:
                         "dimensions": embedding_dimensions,
                     },
                     "score": score,
-                    "source": artifact.get("source"),
+                    "source": item.get("source"),
                     "safety": artifact.get("safety", {}),
-                    "evidence_refs": [f"artifact:{artifact['artifact_id']}", f"storage:{artifact.get('original_storage_ref')}"],
+                    "evidence_refs": [
+                        f"artifact:{artifact['artifact_id']}",
+                        f"storage:{artifact.get('original_storage_ref')}",
+                        str(item.get("derived_representation_ref") or ""),
+                    ],
                 }
-                chunk_id = f"chunk_{_json_hash({'artifact_id': artifact['artifact_id'], 'index': index, 'span': chunk_base['span'], 'text': text})[:16]}"
+                chunk_id = f"chunk_{_json_hash(chunk_base)}"
                 chunk = dict(chunk_base)
                 chunk["evidence_chunk_id"] = chunk_id
+                chunk["evidence_refs"] = [ref for ref in chunk["evidence_refs"] if ref]
                 chunk["evidence_refs"].append(f"evidence_chunk:{chunk_id}")
-                _write_json(self.evidence_chunk_path(chunk_id), chunk)
+                encoded_chunk = (json.dumps(chunk, indent=2, sort_keys=True) + "\n").encode("utf-8")
+                store_content_atomically(
+                    self.evidence_chunk_path(chunk_id),
+                    encoded_chunk,
+                    checksum_sha256=sha256_bytes(encoded_chunk),
+                )
                 chunks.append(chunk)
 
         chunks.sort(key=lambda row: (-float(row.get("score", 0)), str(row.get("artifact_id")), int(row.get("span", {}).get("char_start", 0))))
@@ -9106,6 +10082,99 @@ class LocalRuntimeStore:
             "embedding_status": "embedded" if query_embedding is not None else "not_requested",
             "embedding_model": embedding_model if use_embeddings else None,
         }
+
+    def _validate_citation_ref(
+        self,
+        ref: str,
+        scope: dict[str, str],
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+        """Resolve one immutable citation without persisting a new check record."""
+
+        if not ref.startswith("evidence_chunk:"):
+            return None, None, "UNSUPPORTED_CITATION_REF"
+        ref_match = EVIDENCE_CHUNK_REF_RE.fullmatch(ref)
+        if ref_match is None:
+            return None, None, "INVALID_CITATION_REF"
+        chunk = self.get_evidence_chunk(ref_match.group(1))
+        if chunk is None:
+            return None, None, "UNRESOLVED_CITATION_REF"
+        if chunk.get("scope") != scope:
+            return None, chunk, "CROSS_SCOPE_CITATION_REF"
+        artifact = self.get_artifact(str(chunk.get("artifact_id") or ""), scope)
+        if artifact is None:
+            return None, chunk, "CITATION_ARTIFACT_NOT_FOUND"
+        if not self.original_available(artifact):
+            return None, chunk, "CITATION_ORIGINAL_INTEGRITY_FAILED"
+
+        evidence_bundle_id = str(chunk.get("evidence_bundle_id") or "")
+        if evidence_bundle_id:
+            bundle = self.get_evidence_bundle(evidence_bundle_id)
+            snapshot = (
+                self.get_search_snapshot(str(bundle.get("search_snapshot_id") or ""))
+                if bundle is not None
+                else None
+            )
+            representation_bound = bool(
+                bundle is not None
+                and bundle.get("filters") == scope
+                and bundle.get("evidence_revision_sha256") == chunk.get("evidence_revision_sha256")
+                and snapshot is not None
+                and snapshot.get("result_revision_sha256") == bundle.get("search_result_revision_sha256")
+                and any(
+                    isinstance(item, dict)
+                    and item.get("artifact_id") == chunk.get("artifact_id")
+                    and item.get("derived_representation_id") == chunk.get("derived_representation_id")
+                    and item.get("derived_content_sha256") == chunk.get("derived_content_sha256")
+                    for item in bundle.get("evidence_items", [])
+                )
+            )
+        else:
+            snapshot = self.get_search_snapshot(str(chunk.get("search_snapshot_id") or ""))
+            representation_bound = bool(
+                snapshot
+                and snapshot.get("filters") == scope
+                and snapshot.get("result_revision_sha256") == chunk.get("evidence_revision_sha256")
+                and any(
+                    isinstance(item, dict)
+                    and item.get("artifact_id") == chunk.get("artifact_id")
+                    and item.get("derived_representation_id") == chunk.get("derived_representation_id")
+                    and item.get("derived_content_sha256") == chunk.get("derived_content_sha256")
+                    for item in snapshot.get("results", [])
+                )
+            )
+        if not representation_bound:
+            return None, chunk, "CITATION_EVIDENCE_REVISION_MISMATCH"
+
+        source_text = self._derived_text_from_binding(artifact, chunk)
+        if source_text is None:
+            return None, chunk, "CITATION_DERIVED_REPRESENTATION_MISMATCH"
+        span = chunk.get("span")
+        if not isinstance(span, dict):
+            return None, chunk, "SPAN_IN_SOURCE_MISMATCH"
+        start = span.get("char_start")
+        end = span.get("char_end")
+        if (
+            not isinstance(start, int)
+            or isinstance(start, bool)
+            or not isinstance(end, int)
+            or isinstance(end, bool)
+            or start < 0
+            or end < start
+            or source_text[start:end] != chunk.get("text")
+        ):
+            return None, chunk, "SPAN_IN_SOURCE_MISMATCH"
+        return (
+            {
+                "ref": ref,
+                "artifact_ref": f"artifact:{artifact['artifact_id']}",
+                "derived_representation_ref": chunk.get("derived_representation_ref"),
+                "derived_content_sha256": chunk.get("derived_content_sha256"),
+                "evidence_revision_sha256": chunk.get("evidence_revision_sha256"),
+                "span": {"char_start": start, "char_end": end},
+            },
+            chunk,
+            None,
+        )
 
     def _citation_check(
         self,
@@ -9129,38 +10198,17 @@ class LocalRuntimeStore:
             if not ref.startswith("evidence_chunk:"):
                 errors.append({"ref": ref, "code": "UNSUPPORTED_CITATION_REF"})
                 continue
-            ref_match = EVIDENCE_CHUNK_REF_RE.fullmatch(ref)
-            if ref_match is None:
+            if EVIDENCE_CHUNK_REF_RE.fullmatch(ref) is None:
                 errors.append({"ref": ref, "code": "INVALID_CITATION_REF"})
                 continue
             if retrieval_allowlist is not None and ref not in retrieval_allowlist:
                 errors.append({"ref": ref, "code": "OUT_OF_RETRIEVAL_CITATION_REF"})
                 continue
-            chunk = self.get_evidence_chunk(ref_match.group(1))
-            if chunk is None:
-                errors.append({"ref": ref, "code": "UNRESOLVED_CITATION_REF"})
+            resolved_citation, _, error_code = self._validate_citation_ref(ref, scope)
+            if error_code is not None:
+                errors.append({"ref": ref, "code": error_code})
                 continue
-            if chunk.get("scope") != scope:
-                errors.append({"ref": ref, "code": "CROSS_SCOPE_CITATION_REF"})
-                continue
-            artifact = self.get_artifact(str(chunk.get("artifact_id")), scope)
-            if artifact is None:
-                errors.append({"ref": ref, "code": "CITATION_ARTIFACT_NOT_FOUND"})
-                continue
-            source_text = self._derived_text(artifact)
-            span = chunk.get("span", {})
-            start = int(span.get("char_start", -1))
-            end = int(span.get("char_end", -1))
-            if start < 0 or end < start or source_text[start:end] != chunk.get("text"):
-                errors.append({"ref": ref, "code": "SPAN_IN_SOURCE_MISMATCH"})
-                continue
-            resolved.append(
-                {
-                    "ref": ref,
-                    "artifact_ref": f"artifact:{artifact['artifact_id']}",
-                    "span": {"char_start": start, "char_end": end},
-                }
-            )
+            resolved.append(resolved_citation)
         check_base = {
             "schema_version": "cs.citation_check.v0",
             "output_kind": output_kind,
@@ -9191,6 +10239,12 @@ class LocalRuntimeStore:
             "out_of_retrieval_citation_count": len(
                 [error for error in errors if error["code"] == "OUT_OF_RETRIEVAL_CITATION_REF"]
             ),
+            "evidence_revision_mismatch_count": len(
+                [error for error in errors if error["code"] == "CITATION_EVIDENCE_REVISION_MISMATCH"]
+            ),
+            "derived_representation_mismatch_count": len(
+                [error for error in errors if error["code"] == "CITATION_DERIVED_REPRESENTATION_MISMATCH"]
+            ),
             "errors": errors,
             "checked_at": utc_now(),
         }
@@ -9220,21 +10274,10 @@ class LocalRuntimeStore:
         statement = statement.strip()
         bundle_id = str(bundle.get("evidence_bundle_id") or "")
         evidence_items = bundle.get("evidence_items") if isinstance(bundle.get("evidence_items"), list) else []
-        evidence_revision = _json_hash(
-            {
-                "evidence_bundle_id": bundle_id,
-                "search_snapshot_id": bundle.get("search_snapshot_id"),
-                "artifact_refs": [
-                    f"artifact:{item.get('artifact_id')}"
-                    for item in evidence_items
-                    if isinstance(item, dict) and item.get("artifact_id")
-                ],
-                "snippets": [
-                    str(item.get("snippet") or "")
-                    for item in evidence_items
-                    if isinstance(item, dict)
-                ],
-            }
+        evidence_revision = str(bundle.get("evidence_revision_sha256") or "")
+        evidence_revision_current = bool(
+            re.fullmatch(r"[0-9a-f]{64}", evidence_revision)
+            and evidence_revision == _evidence_bundle_revision_sha256(bundle)
         )
         statement_sha256 = _claim_statement_sha256(statement)
         citation_refs: list[str] = []
@@ -9273,7 +10316,9 @@ class LocalRuntimeStore:
                         [
                             str(chunk.get("text") or "")
                             for chunk in cited_chunks
-                            if isinstance(chunk, dict) and chunk.get("evidence_bundle_id") == bundle_id
+                            if isinstance(chunk, dict)
+                            and chunk.get("evidence_bundle_id") == bundle_id
+                            and chunk.get("evidence_revision_sha256") == evidence_revision
                         ],
                     )
                     if anchor_validation.get("status") == "passed":
@@ -9286,6 +10331,7 @@ class LocalRuntimeStore:
                 scope,
                 query=statement,
                 evidence_bundle_id=bundle_id,
+                evidence_revision_sha256=str(bundle.get("evidence_revision_sha256") or ""),
                 model_provider="local_test",
             )
             chunks = [chunk for chunk in chunks_result.get("chunks", []) if isinstance(chunk, dict)]
@@ -9306,7 +10352,11 @@ class LocalRuntimeStore:
         citations_bound_to_bundle = bool(citation_refs)
         for ref in citation_refs:
             chunk = self.get_evidence_chunk(ref.split(":", 1)[1]) if ref.startswith("evidence_chunk:") else None
-            if chunk is None or chunk.get("evidence_bundle_id") != bundle_id:
+            if (
+                chunk is None
+                or chunk.get("evidence_bundle_id") != bundle_id
+                or chunk.get("evidence_revision_sha256") != evidence_revision
+            ):
                 citations_bound_to_bundle = False
                 break
         citation_integrity_passed = bool(
@@ -9314,14 +10364,15 @@ class LocalRuntimeStore:
             and citation_check.get("status") == "passed"
             and citations_bound_to_bundle
         )
-        support_passed = bool(
+        source_supported = bool(
             statement
+            and evidence_revision_current
             and anchor_validation.get("status") == "passed"
             and citation_integrity_passed
         )
         support_base = {
             "schema_version": "cs.claim_statement_support.v0",
-            "status": "passed" if support_passed else "not_verified",
+            "status": "source_supported" if source_supported else "not_verified",
             "statement_sha256": statement_sha256,
             "statement_revision": 1,
             "evidence_bundle_id": bundle_id,
@@ -9334,12 +10385,14 @@ class LocalRuntimeStore:
                 else []
             ),
             "citation_integrity_state": "passed" if citation_integrity_passed else "not_verified",
-            "citations_bound_to_evidence_revision": citations_bound_to_bundle,
-            "statement_support_state": "deterministic_anchor_passed" if support_passed else "not_verified",
+            "citations_bound_to_evidence_revision": citations_bound_to_bundle and evidence_revision_current,
+            "source_support_state": "passed" if source_supported else "not_verified",
+            "statement_support_state": "source_supported" if source_supported else "not_verified",
             "semantic_faithfulness_state": "human_required",
             "semantic_support_verified": False,
+            "semantic_review_required": True,
             "anchor_validation": anchor_validation,
-            "approval_eligible": support_passed,
+            "approval_eligible": False,
         }
         return {
             **support_base,
@@ -9453,9 +10506,14 @@ class LocalRuntimeStore:
             if source_type in excluded_source_types:
                 continue
             original_available = self.original_available(artifact)
-            if search_mode == "evidence" and not original_available:
+            derived_binding = self._derived_representation_binding(artifact)
+            if search_mode == "evidence" and (not original_available or derived_binding is None):
                 continue
-            text = self._derived_text(artifact)
+            text = (
+                self._derived_text_from_binding(artifact, derived_binding) or ""
+                if derived_binding is not None
+                else ""
+            )
             source_ref = str(source.get("ref") or "").strip()
             filename = str(source.get("filename") or "").strip()
             first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
@@ -9498,8 +10556,7 @@ class LocalRuntimeStore:
             start = text_haystack.find(first_term) if first_term and first_term in text_haystack else 0
             start = max(start, 0)
             snippet = text[start : start + 180].replace("\n", " ").strip()
-            results.append(
-                {
+            result = {
                     "result_type": "artifact",
                     "result_ref": f"artifact:{artifact['artifact_id']}",
                     "artifact_id": artifact["artifact_id"],
@@ -9520,7 +10577,10 @@ class LocalRuntimeStore:
                         f"storage:{artifact['original_storage_ref']}",
                     ],
                 }
-            )
+            if derived_binding is not None:
+                result.update(derived_binding)
+                result["evidence_refs"].append(derived_binding["derived_representation_ref"])
+            results.append(result)
         for ontology_object in self._ontology_object_records(scope) if "ontology_object" in selected_result_types else []:
             haystack_parts = [
                 str(ontology_object.get("label", "")),
@@ -9545,11 +10605,18 @@ class LocalRuntimeStore:
             evidence_refs = list(ontology_object.get("evidence_refs", []))
             artifact_ref = next((ref for ref in evidence_refs if str(ref).startswith("artifact:")), "")
             artifact_id = artifact_ref.split(":", 1)[1] if artifact_ref else None
+            ontology_artifact = self.get_artifact(str(artifact_id), scope) if artifact_id else None
+            derived_binding = (
+                self._derived_representation_binding(ontology_artifact)
+                if isinstance(ontology_artifact, dict) and self.original_available(ontology_artifact)
+                else None
+            )
+            if search_mode == "evidence" and artifact_id and derived_binding is None:
+                continue
             snippet = f"{ontology_object.get('seed_type')}: {ontology_object.get('label')}"
             if ontology_object.get("properties"):
                 snippet = f"{snippet} properties={json.dumps(ontology_object.get('properties'), sort_keys=True)[:160]}"
-            results.append(
-                {
+            result = {
                     "result_type": "ontology_object",
                     "result_ref": f"ontology_object:{ontology_object['ontology_object_id']}",
                     "ontology_object_id": ontology_object["ontology_object_id"],
@@ -9561,7 +10628,12 @@ class LocalRuntimeStore:
                     "match_reasons": match_reasons,
                     "evidence_refs": [f"ontology_object:{ontology_object['ontology_object_id']}", *evidence_refs],
                 }
-            )
+            if derived_binding is not None:
+                result.update(derived_binding)
+                result["derived_text_ref"] = derived_binding["derived_storage_ref"]
+                result["original_storage_ref"] = ontology_artifact.get("original_storage_ref")
+                result["evidence_refs"].append(derived_binding["derived_representation_ref"])
+            results.append(result)
         for brief in brief_records:
             key_points = brief.get("key_points") if isinstance(brief.get("key_points"), list) else []
             uncertainty = brief.get("uncertainty") if isinstance(brief.get("uncertainty"), list) else []
@@ -9684,15 +10756,26 @@ class LocalRuntimeStore:
             ]
         duration_ms = round((perf_counter() - started) * 1000, 3)
         persisted_query = redact_text(query)
+        query_sha256 = sha256_bytes(query.encode("utf-8"))
+        result_revision_sha256 = _search_result_revision_sha256(
+            {
+                "query_sha256": query_sha256,
+                "filters": scope,
+                "search_mode": search_mode,
+                "result_types": sorted(selected_result_types),
+                "results": results,
+            }
+        )
         snapshot_base = {
             "schema_version": "cs.search_snapshot.v0",
             "query": persisted_query,
-            "query_sha256": sha256_bytes(query.encode("utf-8")),
+            "query_sha256": query_sha256,
             "filters": scope,
             "search_mode": search_mode,
             "result_types": sorted(selected_result_types),
             "result_count": len(results),
             "results": results,
+            "result_revision_sha256": result_revision_sha256,
             "created_at": utc_now(),
             "duration_ms": duration_ms,
         }
@@ -9717,11 +10800,17 @@ class LocalRuntimeStore:
         return {"snapshot": snapshot, "audit_event": event}
 
     def create_evidence_bundle(self, snapshot_id: str, scope: dict[str, str]) -> dict[str, Any]:
-        snapshot = self.get_search_snapshot(snapshot_id)
+        try:
+            snapshot = self._load_search_snapshot(snapshot_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return {"status": "integrity_failed", "reason": "search_snapshot_record_unreadable"}
         if snapshot is None:
             return {"status": "not_found"}
         if snapshot.get("filters") != scope:
             return {"status": "scope_denied", "resource_scope": snapshot.get("filters")}
+        identity_error = self._search_snapshot_identity_error(snapshot, snapshot_id)
+        if identity_error is not None:
+            return {"status": "integrity_failed", "reason": identity_error}
         if str(snapshot.get("search_mode") or "evidence") != "evidence":
             return {
                 "status": "invalid_search_mode",
@@ -9731,14 +10820,17 @@ class LocalRuntimeStore:
         evidence_items, evidence_error = self._evidence_items_from_snapshot(snapshot, scope)
         if evidence_error is not None:
             return evidence_error
-        bundle_base = {
+        bundle_base: dict[str, Any] = {
             "schema_version": "cs.evidence_bundle.v0",
             "search_snapshot_id": snapshot_id,
             "query": snapshot["query"],
+            "query_sha256": snapshot.get("query_sha256"),
+            "search_result_revision_sha256": snapshot.get("result_revision_sha256"),
             "filters": scope,
             "result_snapshot": {
                 "search_snapshot_id": snapshot_id,
                 "query": snapshot["query"],
+                "query_sha256": snapshot.get("query_sha256"),
                 "filters": scope,
                 "result_count": snapshot.get("result_count", 0),
                 "results": snapshot.get("results", []),
@@ -9746,6 +10838,9 @@ class LocalRuntimeStore:
             "evidence_items": evidence_items,
             "created_at": utc_now(),
         }
+        evidence_revision_sha256 = _evidence_bundle_revision_sha256(bundle_base)
+        bundle_base["evidence_revision_sha256"] = evidence_revision_sha256
+        bundle_base["result_snapshot"]["evidence_revision_sha256"] = evidence_revision_sha256
         bundle_id = f"evb_{_json_hash(bundle_base)[:16]}"
         bundle = dict(bundle_base)
         bundle["evidence_bundle_id"] = bundle_id
@@ -9758,12 +10853,115 @@ class LocalRuntimeStore:
         )
         return {"bundle": bundle, "audit_event": event}
 
-    def show_evidence_bundle(self, bundle_id: str, scope: dict[str, str]) -> dict[str, Any]:
-        bundle = self.get_evidence_bundle(bundle_id)
+    def _validated_evidence_bundle_items(
+        self,
+        bundle: dict[str, Any],
+        scope: dict[str, str],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        """Resolve one immutable Evidence Bundle chain without borrowing current metadata."""
+
+        bundle_id = str(bundle.get("evidence_bundle_id") or "")
+        identity_error = self._evidence_bundle_identity_error(bundle, bundle_id)
+        if identity_error is not None:
+            return [], {"status": "integrity_failed", "reason": identity_error}
+        revision = str(bundle.get("evidence_revision_sha256") or "")
+        if not re.fullmatch(r"[0-9a-f]{64}", revision) or revision != _evidence_bundle_revision_sha256(bundle):
+            return [], {"status": "integrity_failed", "reason": "evidence_bundle_revision_changed"}
+
+        snapshot_id = str(bundle.get("search_snapshot_id") or "")
+        snapshot = self.get_search_snapshot(snapshot_id) if snapshot_id else None
+        snapshot_revision = str((snapshot or {}).get("result_revision_sha256") or "")
+        if not (
+            snapshot
+            and snapshot.get("filters") == scope
+            and re.fullmatch(r"[0-9a-f]{64}", snapshot_revision)
+            and snapshot_revision == _search_result_revision_sha256(snapshot)
+            and bundle.get("search_result_revision_sha256") == snapshot_revision
+            and bundle.get("query_sha256") == snapshot.get("query_sha256")
+            and bundle.get("query") == snapshot.get("query")
+        ):
+            return [], {
+                "status": "integrity_failed",
+                "reason": "evidence_bundle_search_snapshot_missing_or_changed",
+                "search_snapshot_id": snapshot_id or None,
+            }
+
+        expected_result_snapshot = {
+            "search_snapshot_id": snapshot_id,
+            "query": snapshot.get("query"),
+            "query_sha256": snapshot.get("query_sha256"),
+            "filters": scope,
+            "result_count": snapshot.get("result_count", 0),
+            "results": snapshot.get("results", []),
+            "evidence_revision_sha256": revision,
+        }
+        if bundle.get("result_snapshot") != expected_result_snapshot:
+            return [], {
+                "status": "integrity_failed",
+                "reason": "evidence_bundle_result_snapshot_missing_or_changed",
+                "search_snapshot_id": snapshot_id,
+            }
+
+        evidence_items = bundle.get("evidence_items")
+        if not isinstance(evidence_items, list):
+            return [], {"status": "integrity_failed", "reason": "invalid_evidence_items"}
+
+        resolved_items: list[dict[str, Any]] = []
+        for item in evidence_items:
+            if not isinstance(item, dict) or not item.get("artifact_id"):
+                return [], {"status": "integrity_failed", "reason": "invalid_evidence_item"}
+            artifact_id = str(item["artifact_id"])
+            artifact = self.get_artifact(artifact_id, scope)
+            if artifact is None or artifact.get("scope") != scope:
+                return [], {
+                    "status": "integrity_failed",
+                    "reason": "evidence_artifact_missing_or_outside_scope",
+                    "artifact_id": artifact_id,
+                }
+            if (
+                item.get("artifact_checksum_sha256") != artifact.get("checksum_sha256")
+                or item.get("original_storage_ref") != artifact.get("original_storage_ref")
+                or not self.original_available(artifact)
+            ):
+                return [], {
+                    "status": "integrity_failed",
+                    "reason": "evidence_original_missing_or_changed",
+                    "artifact_id": artifact_id,
+                }
+            derived_text = self._derived_text_from_binding(artifact, item)
+            if derived_text is None:
+                return [], {
+                    "status": "integrity_failed",
+                    "reason": "derived_representation_missing_or_changed",
+                    "artifact_id": artifact_id,
+                }
+            resolved_items.append({"item": item, "artifact": artifact, "derived_text": derived_text})
+        return resolved_items, None
+
+    def _checked_evidence_bundle(
+        self,
+        bundle_id: str,
+        scope: dict[str, str],
+    ) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, Any] | None]:
+        try:
+            bundle = self._load_evidence_bundle(bundle_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None, [], {
+                "status": "integrity_failed",
+                "reason": "evidence_bundle_record_unreadable",
+            }
         if bundle is None:
-            return {"status": "not_found"}
+            return None, [], {"status": "not_found"}
         if bundle.get("filters") != scope:
-            return {"status": "scope_denied", "resource_scope": bundle.get("filters")}
+            return bundle, [], {"status": "scope_denied", "resource_scope": bundle.get("filters")}
+        resolved_items, integrity_error = self._validated_evidence_bundle_items(bundle, scope)
+        return bundle, resolved_items, integrity_error
+
+    def show_evidence_bundle(self, bundle_id: str, scope: dict[str, str]) -> dict[str, Any]:
+        bundle, _, error = self._checked_evidence_bundle(bundle_id, scope)
+        if error is not None:
+            return error
+        assert bundle is not None
         event = self.append_audit(
             "evidence_bundle.read",
             scope,
@@ -9773,37 +10971,42 @@ class LocalRuntimeStore:
         return {"bundle": bundle, "audit_event": event}
 
     def view_evidence_bundle(self, bundle_id: str, scope: dict[str, str]) -> dict[str, Any]:
-        bundle = self.get_evidence_bundle(bundle_id)
-        if bundle is None:
-            return {"status": "not_found"}
-        if bundle.get("filters") != scope:
-            return {"status": "scope_denied", "resource_scope": bundle.get("filters")}
-
+        bundle, resolved_items, error = self._checked_evidence_bundle(bundle_id, scope)
+        if error is not None:
+            return error
+        assert bundle is not None
         viewer_items = []
-        for item in bundle.get("evidence_items", []):
-            artifact = self.get_artifact(item["artifact_id"], scope)
-            if artifact is None:
-                return {"status": "not_found", "artifact_id": item["artifact_id"]}
-            if artifact.get("scope") != scope:
-                return {"status": "scope_denied", "resource_scope": artifact.get("scope")}
-            derived_text = self._derived_text(artifact)
+        for resolved in resolved_items:
+            item = resolved["item"]
+            artifact = resolved["artifact"]
+            derived_text = resolved["derived_text"]
             viewer_items.append(
                 {
                     "artifact_id": artifact["artifact_id"],
                     "original": {
-                        "storage_ref": artifact.get("original_storage_ref"),
-                        "media_type": artifact.get("media_type"),
-                        "source": artifact.get("source"),
-                        "raw_original_access": artifact.get("raw_original_access"),
-                        "size_bytes": artifact.get("original_size_bytes"),
+                        "storage_ref": item.get("original_storage_ref"),
+                        "media_type": item.get("media_type", artifact.get("media_type")),
+                        "source": item.get("source"),
+                        "raw_original_access": item.get("raw_original_access", artifact.get("raw_original_access")),
+                        "size_bytes": item.get("original_size_bytes", artifact.get("original_size_bytes")),
                     },
                     "derived": {
-                        "text_ref": artifact.get("derived", {}).get("text_ref"),
-                        "status": artifact.get("derived", {}).get("status"),
+                        "text_ref": item.get("derived_storage_ref") or item.get("derived_text_ref"),
+                        "status": "ready",
                         "text_preview": derived_text[:240].replace("\n", " ").strip(),
-                        "metadata": artifact.get("derived"),
+                        "metadata": {
+                            "derived_representation_id": item.get("derived_representation_id"),
+                            "derived_representation_ref": item.get("derived_representation_ref"),
+                            "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                            "content_checksum_sha256": item.get("derived_content_sha256"),
+                            "content_size_bytes": item.get("derived_content_size_bytes"),
+                            "storage_ref": item.get("derived_storage_ref"),
+                            "representation_type": item.get("representation_type"),
+                            "extractor": item.get("extractor"),
+                            "extractor_version": item.get("extractor_version"),
+                        },
                     },
-                    "provenance": artifact.get("provenance"),
+                    "provenance": item.get("provenance"),
                     "snippet": item.get("snippet"),
                 }
             )
@@ -9838,11 +11041,10 @@ class LocalRuntimeStore:
         embedding_model: str = DEFAULT_EMBEDDING_MODEL,
         ollama_base_url: str | None = None,
     ) -> dict[str, Any]:
-        bundle = self.get_evidence_bundle(bundle_id)
-        if bundle is None:
-            return {"status": "not_found"}
-        if bundle.get("filters") != scope:
-            return {"status": "scope_denied", "resource_scope": bundle.get("filters")}
+        bundle, resolved_items, bundle_error = self._checked_evidence_bundle(bundle_id, scope)
+        if bundle_error is not None:
+            return bundle_error
+        assert bundle is not None
 
         evidence_items = bundle.get("evidence_items", [])
         if not evidence_items:
@@ -9857,6 +11059,7 @@ class LocalRuntimeStore:
                 scope,
                 query=str(bundle.get("query") or ""),
                 evidence_bundle_id=bundle_id,
+                evidence_revision_sha256=str(bundle.get("evidence_revision_sha256") or ""),
                 model_provider=model_provider,
                 embedding_model=embedding_model,
                 ollama_base_url=ollama_base_url,
@@ -9942,6 +11145,9 @@ class LocalRuntimeStore:
                     "span": chunk.get("span"),
                     "original_storage_ref": chunk.get("original_storage_ref"),
                     "derived_text_ref": chunk.get("derived_text_ref"),
+                    "derived_representation_ref": chunk.get("derived_representation_ref"),
+                    "derived_content_sha256": chunk.get("derived_content_sha256"),
+                    "evidence_revision_sha256": chunk.get("evidence_revision_sha256"),
                 }
                 for chunk in chunks
             ]
@@ -9951,6 +11157,7 @@ class LocalRuntimeStore:
                     f"search_snapshot:{bundle.get('search_snapshot_id')}",
                     *[link["artifact_ref"] for link in evidence_links],
                     *[str(link.get("evidence_chunk_ref")) for link in evidence_links if link.get("evidence_chunk_ref")],
+                    *[str(link.get("derived_representation_ref")) for link in evidence_links if link.get("derived_representation_ref")],
                 }
             )
             prompt_boundary = self._prompt_boundary(
@@ -9995,6 +11202,9 @@ class LocalRuntimeStore:
                         "snippet": snippet,
                         "original_storage_ref": item.get("original_storage_ref"),
                         "derived_text_ref": item.get("derived_text_ref"),
+                        "derived_representation_ref": item.get("derived_representation_ref"),
+                        "derived_content_sha256": item.get("derived_content_sha256"),
+                        "evidence_revision_sha256": bundle.get("evidence_revision_sha256"),
                     }
                 )
             trust_label_reason = (
@@ -10012,6 +11222,11 @@ class LocalRuntimeStore:
                 embedding_model=embedding_model if model_provider == "ollama" else None,
             )
             evidence_refs = [link["artifact_ref"] for link in evidence_links]
+            evidence_refs.extend(
+                str(link.get("derived_representation_ref"))
+                for link in evidence_links
+                if link.get("derived_representation_ref")
+            )
             evidence_refs.extend(
                 [
                     f"evidence_bundle:{bundle_id}",
@@ -10061,8 +11276,28 @@ class LocalRuntimeStore:
                 "search_snapshot_id": bundle.get("search_snapshot_id"),
                 "query": bundle.get("query"),
                 "filters": scope,
+                "evidence_revision_sha256": bundle.get("evidence_revision_sha256"),
                 "evidence_item_count": len(evidence_items),
                 "artifact_refs": [link["artifact_ref"] for link in evidence_links],
+                "derived_representation_refs": sorted(
+                    {
+                        str(item.get("derived_representation_ref"))
+                        for item in evidence_items
+                        if isinstance(item, dict) and item.get("derived_representation_ref")
+                    }
+                ),
+                "representation_bindings": [
+                    {
+                        "artifact_id": item.get("artifact_id"),
+                        "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                        "derived_representation_id": item.get("derived_representation_id"),
+                        "derived_representation_ref": item.get("derived_representation_ref"),
+                        "derived_content_sha256": item.get("derived_content_sha256"),
+                        "derived_content_size_bytes": item.get("derived_content_size_bytes"),
+                    }
+                    for item in evidence_items
+                    if isinstance(item, dict)
+                ],
             },
             **value_plane,
             "key_points": key_points,
@@ -10139,18 +11374,61 @@ class LocalRuntimeStore:
             "actions": "action",
             "memories": "memory",
         }.get(record_kind.lower(), record_kind.lower())
-        getters = {
-            "artifact": lambda value: self.get_artifact(value, scope),
-            "brief": self.get_brief,
-            "claim": self.get_claim,
-            "action": self.get_action,
-            "memory": self.get_memory,
-        }
-        getter = getters.get(normalized)
-        if getter is None:
+        if normalized == "artifact":
+            try:
+                record = self._get_artifact_unchecked(record_id, scope)
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                return {
+                    "status": "integrity_failed",
+                    "record_kind": "artifact",
+                    "reason": "artifact_record_unreadable",
+                }
+            if record is None:
+                return {"status": "not_found", "record_kind": "artifact"}
+            if record.get("scope") != scope:
+                return {
+                    "status": "scope_denied",
+                    "record_kind": "artifact",
+                    "resource_scope": record.get("scope"),
+                }
+            identity_error = self._artifact_identity_error(record, record_id, scope)
+            if identity_error is not None:
+                return {
+                    "status": "integrity_failed",
+                    "record_kind": "artifact",
+                    "reason": identity_error,
+                }
+        else:
+            getters = {
+                "brief": self.get_brief,
+                "claim": self.get_claim,
+                "action": self.get_action,
+                "memory": self.get_memory,
+            }
+            getter = getters.get(normalized)
+            if getter is None:
+                return {"status": "unsupported_kind", "record_kind": record_kind}
+            record = getter(record_id)
+        if normalized not in {"artifact", "brief", "claim", "action", "memory"}:
             return {"status": "unsupported_kind", "record_kind": record_kind}
-        record = getter(record_id)
         if record is None:
+            path_getters = {
+                "brief": self.brief_path,
+                "claim": self.claim_path,
+                "action": self.action_path,
+                "memory": self.memory_path,
+            }
+            path_getter = path_getters.get(normalized)
+            try:
+                record_path_exists = path_getter is not None and path_getter(record_id).exists()
+            except ValueError:
+                record_path_exists = False
+            if record_path_exists:
+                return {
+                    "status": "integrity_failed",
+                    "record_kind": normalized,
+                    "reason": f"{normalized}_record_unreadable_or_changed",
+                }
             return {"status": "not_found", "record_kind": normalized}
         if record.get("scope") != scope:
             return {"status": "scope_denied", "record_kind": normalized, "resource_scope": record.get("scope")}
@@ -10167,6 +11445,9 @@ class LocalRuntimeStore:
         return {"record": record, "audit_event": event}
 
     def original_available(self, artifact: dict[str, Any]) -> bool:
+        artifact_id = str(artifact.get("artifact_id") or "")
+        if self._artifact_identity_error(artifact, artifact_id) is not None:
+            return False
         checksum = str(artifact.get("checksum_sha256") or "")
         storage_ref = str(artifact.get("original_storage_ref") or "")
         expected_size = artifact.get("original_size_bytes")
@@ -10178,20 +11459,36 @@ class LocalRuntimeStore:
         ):
             return False
         original_root = self.original_dir.resolve()
-        original_path = (original_root / checksum).resolve()
-        if original_path.parent != original_root or not original_path.is_file():
-            return False
-        try:
-            stat = original_path.stat()
-        except OSError:
-            return False
-        if stat.st_size != expected_size:
-            return False
-        return _original_file_matches(
-            str(original_path),
-            stat.st_mtime_ns,
-            expected_size,
-            checksum,
+        original_path = self.original_dir / checksum
+        return bool(
+            original_path.parent.resolve() == original_root
+            and not original_path.is_symlink()
+            and verify_content_file(
+                original_path,
+                checksum_sha256=checksum,
+                size_bytes=expected_size,
+            )
+        )
+
+    def _read_verified_original_bytes(self, artifact: dict[str, Any]) -> bytes | None:
+        checksum = str(artifact.get("checksum_sha256") or "")
+        storage_ref = str(artifact.get("original_storage_ref") or "")
+        expected_size = artifact.get("original_size_bytes")
+        if (
+            not re.fullmatch(r"[0-9a-f]{64}", checksum)
+            or storage_ref != f"sha256:{checksum}"
+            or not isinstance(expected_size, int)
+            or expected_size < 0
+        ):
+            return None
+        original_root = self.original_dir.resolve()
+        original_path = self.original_dir / checksum
+        if original_path.parent.resolve() != original_root or original_path.is_symlink():
+            return None
+        return read_verified_content_file(
+            original_path,
+            checksum_sha256=checksum,
+            size_bytes=expected_size,
         )
 
     def read_artifact_original(
@@ -10201,7 +11498,14 @@ class LocalRuntimeStore:
         *,
         reason: str,
     ) -> dict[str, Any]:
-        artifact = self.get_artifact(artifact_id, scope)
+        try:
+            artifact = self._get_artifact_unchecked(artifact_id, scope)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return {
+                "status": "integrity_failed",
+                "record_kind": "artifact",
+                "reason": "artifact_record_unreadable",
+            }
         if artifact is None:
             return {"status": "not_found", "record_kind": "artifact"}
         if artifact.get("scope") != scope:
@@ -10210,21 +11514,25 @@ class LocalRuntimeStore:
                 "record_kind": "artifact",
                 "resource_scope": artifact.get("scope"),
             }
+        identity_error = self._artifact_identity_error(artifact, artifact_id, scope)
+        if identity_error is not None:
+            return {
+                "status": "integrity_failed",
+                "record_kind": "artifact",
+                "reason": identity_error,
+            }
         checksum = str(artifact.get("checksum_sha256") or "")
         storage_ref = str(artifact.get("original_storage_ref") or "")
         if not re.fullmatch(r"[0-9a-f]{64}", checksum) or storage_ref != f"sha256:{checksum}":
             return {"status": "integrity_failed", "reason": "invalid_original_storage_ref"}
         original_root = self.original_dir.resolve()
-        original_path = (original_root / checksum).resolve()
-        if original_path.parent != original_root:
+        original_path = self.original_dir / checksum
+        if original_path.parent.resolve() != original_root or original_path.is_symlink():
             return {"status": "integrity_failed", "reason": "invalid_original_path"}
         if not original_path.is_file():
             return {"status": "integrity_failed", "reason": "original_missing"}
-        content = original_path.read_bytes()
-        expected_size = artifact.get("original_size_bytes")
-        if not isinstance(expected_size, int) or expected_size < 0:
-            return {"status": "integrity_failed", "reason": "invalid_original_size"}
-        if sha256_bytes(content) != checksum or len(content) != expected_size:
+        content = self._read_verified_original_bytes(artifact)
+        if content is None:
             return {"status": "integrity_failed", "reason": "original_content_mismatch"}
         event = self.append_audit(
             "artifact.original.read",
@@ -10307,11 +11615,10 @@ class LocalRuntimeStore:
         ontology_object_refs: list[str] | None = None,
         related_brief: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        bundle = self.get_evidence_bundle(bundle_id)
-        if bundle is None:
-            return {"status": "not_found"}
-        if bundle.get("filters") != scope:
-            return {"status": "scope_denied", "resource_scope": bundle.get("filters")}
+        bundle, _, bundle_error = self._checked_evidence_bundle(bundle_id, scope)
+        if bundle_error is not None:
+            return bundle_error
+        assert bundle is not None
         evidence_items = bundle.get("evidence_items")
         if not isinstance(evidence_items, list) or not evidence_items:
             return {
@@ -10336,12 +11643,24 @@ class LocalRuntimeStore:
             scope=scope,
             related_brief=related_brief,
         )
-        support_passed = statement_support.get("status") == "passed"
+        source_supported = statement_support.get("status") == "source_supported"
+        representation_bindings = [
+            {
+                "artifact_id": item.get("artifact_id"),
+                "artifact_checksum_sha256": item.get("artifact_checksum_sha256"),
+                "derived_representation_id": item.get("derived_representation_id"),
+                "derived_representation_ref": item.get("derived_representation_ref"),
+                "derived_content_sha256": item.get("derived_content_sha256"),
+                "derived_content_size_bytes": item.get("derived_content_size_bytes"),
+            }
+            for item in evidence_items
+            if isinstance(item, dict)
+        ]
 
         claim_base = {
             "schema_version": "cs.claim.v0",
             "status": "draft",
-            "trust_state": "evidence_backed" if support_passed else "draft",
+            "trust_state": "draft",
             "statement": normalized_statement,
             "statement_support": statement_support,
             "rationale": (
@@ -10373,8 +11692,17 @@ class LocalRuntimeStore:
                 "search_snapshot_id": bundle.get("search_snapshot_id"),
                 "query": bundle.get("query"),
                 "filters": scope,
+                "evidence_revision_sha256": bundle.get("evidence_revision_sha256"),
                 "evidence_item_count": len(evidence_items),
                 "artifact_refs": [f"artifact:{item['artifact_id']}" for item in evidence_items],
+                "derived_representation_refs": sorted(
+                    {
+                        str(item.get("derived_representation_ref"))
+                        for item in evidence_items
+                        if isinstance(item, dict) and item.get("derived_representation_ref")
+                    }
+                ),
+                "representation_bindings": representation_bindings,
                 "result_refs": [
                     f"search_snapshot:{bundle.get('search_snapshot_id')}",
                     f"evidence_bundle:{bundle_id}",
@@ -10396,13 +11724,13 @@ class LocalRuntimeStore:
                 "usage_boundary": "context_only",
             },
             "authority": {
-                "can_be_approved": support_passed,
+                "can_be_approved": False,
                 "can_publish_shared_truth": False,
                 "can_drive_autonomous_action": False,
                 "blocked_reason": (
-                    "Owner approval is required before shared truth or autonomous action use."
-                    if support_passed
-                    else "The exact Claim statement needs a same-bundle source anchor before approval."
+                    "Source support is attached, but statement-level semantic review is required before approval."
+                    if source_supported
+                    else "The exact Claim statement needs same-revision source support and semantic review before approval."
                 ),
             },
             "activity_refs": [],
@@ -10425,6 +11753,10 @@ class LocalRuntimeStore:
                 "statement_sha256": statement_support.get("statement_sha256"),
                 "support_check_id": statement_support.get("support_check_id"),
                 "statement_support_state": statement_support.get("statement_support_state"),
+                "source_support_state": statement_support.get("source_support_state"),
+                "semantic_support_verified": False,
+                "approval_eligible": False,
+                "evidence_revision_sha256": bundle.get("evidence_revision_sha256"),
                 "citation_refs": statement_support.get("citation_refs", []),
                 "citation_check_refs": statement_support.get("citation_check_refs", []),
                 "ontology_context_refs": [f"ontology_object:{obj['ontology_object_id']}" for obj in ontology_context_objects],
@@ -10443,7 +11775,27 @@ class LocalRuntimeStore:
             return {"status": "scope_denied", "resource_scope": claim.get("scope")}
 
         evidence = claim.get("evidence_bundle", {})
-        evidence_item_count = int(evidence.get("evidence_item_count", 0) or 0)
+        evidence_integrity = claim.get("evidence_integrity") if isinstance(claim.get("evidence_integrity"), dict) else {}
+        if evidence_integrity.get("status") == "failed":
+            event = self.append_audit(
+                "claim.approval.denied",
+                scope,
+                {"type": "claim", "id": claim_id},
+                {
+                    "reason": "claim_evidence_integrity_failed",
+                    "required": "Restore the exact revision-bound Evidence Bundle, original, and Derived Representation before Claim review.",
+                    "integrity_reason": evidence_integrity.get("reason"),
+                    "semantic_support_verified": False,
+                    "approval_eligible": False,
+                },
+            )
+            return {"status": "integrity_failed", "claim": claim, "audit_event": event}
+        raw_evidence_item_count = evidence.get("evidence_item_count", 0)
+        evidence_item_count = (
+            raw_evidence_item_count
+            if isinstance(raw_evidence_item_count, int) and not isinstance(raw_evidence_item_count, bool)
+            else 0
+        )
         artifact_refs = evidence.get("artifact_refs", [])
         if evidence_item_count <= 0 or not artifact_refs:
             event = self.append_audit(
@@ -10472,64 +11824,53 @@ class LocalRuntimeStore:
             if bundle is not None and bundle.get("filters") == scope
             else {}
         )
-        support_is_current = bool(
-            stored_support.get("status") == "passed"
-            and current_support.get("status") == "passed"
+        source_support_is_current = bool(
+            stored_support.get("status") == "source_supported"
+            and current_support.get("status") == "source_supported"
             and stored_support.get("statement_sha256") == current_support.get("statement_sha256")
             and stored_support.get("evidence_revision_sha256") == current_support.get("evidence_revision_sha256")
             and stored_support.get("citation_refs") == current_support.get("citation_refs")
             and stored_support.get("citations_bound_to_evidence_revision") is True
             and current_support.get("citations_bound_to_evidence_revision") is True
         )
-        if not support_is_current:
+        if not source_support_is_current:
             event = self.append_audit(
                 "claim.approval.denied",
                 scope,
                 {"type": "claim", "id": claim_id},
                 {
-                    "reason": "statement_support_missing_or_stale",
+                    "reason": "statement_source_support_missing_or_stale",
                     "required": "Bind the exact Claim statement to citation-checked source text from the current Evidence Bundle revision.",
                     "statement_sha256": _claim_statement_sha256(str(claim.get("statement") or "")),
                     "stored_support_check_id": stored_support.get("support_check_id"),
                     "current_support_check_id": current_support.get("support_check_id"),
                     "stored_support_state": stored_support.get("statement_support_state"),
                     "current_support_state": current_support.get("statement_support_state"),
+                    "semantic_support_verified": False,
+                    "approval_eligible": False,
                 },
             )
             return {"status": "support_required", "claim": claim, "audit_event": event}
-
-        approved = dict(claim)
-        approved["status"] = "approved"
-        approved["trust_state"] = "approved"
-        approved["approved_at"] = utc_now()
-        approved["statement_support"] = {
-            **current_support,
-            "approval_revalidated_at": approved["approved_at"],
-            "approval_revalidated": True,
-        }
-        approved["authority"] = {
-            "can_be_approved": True,
-            "can_publish_shared_truth": True,
-            "can_drive_autonomous_action": False,
-            "blocked_reason": "Autonomous action still requires a governed action or mission path.",
-        }
-        _write_json(self.claim_path(claim_id), approved)
         event = self.append_audit(
-            "claim.approved",
+            "claim.approval.denied",
             scope,
             {"type": "claim", "id": claim_id},
             {
+                "reason": "semantic_support_review_required",
+                "required": "Record statement-level semantic support for the exact Claim, citations, and Evidence Bundle revision before owner approval.",
                 "evidence_bundle_id": evidence.get("evidence_bundle_id"),
                 "evidence_item_count": evidence_item_count,
                 "artifact_refs": artifact_refs,
-                "statement_sha256": current_support.get("statement_sha256"),
+                "statement_sha256": _claim_statement_sha256(str(claim.get("statement") or "")),
                 "evidence_revision_sha256": current_support.get("evidence_revision_sha256"),
-                "support_check_id": current_support.get("support_check_id"),
-                "citation_refs": current_support.get("citation_refs", []),
-                "citation_check_refs": current_support.get("citation_check_refs", []),
+                "stored_support_check_id": stored_support.get("support_check_id"),
+                "current_support_check_id": current_support.get("support_check_id"),
+                "source_support_is_current": source_support_is_current,
+                "semantic_support_verified": False,
+                "approval_eligible": False,
             },
         )
-        return {"status": "approved", "claim": approved, "audit_event": event}
+        return {"status": "semantic_support_required", "claim": claim, "audit_event": event}
 
     def show_claim(self, claim_id: str, scope: dict[str, str]) -> dict[str, Any]:
         result = self.read_product_record("claim", claim_id, scope, reason="cli_claim_show")
@@ -10546,6 +11887,7 @@ class LocalRuntimeStore:
         if evidence.get("search_snapshot_id"):
             refs.append(f"search_snapshot:{evidence['search_snapshot_id']}")
         refs.extend(evidence.get("artifact_refs", []))
+        refs.extend(evidence.get("derived_representation_refs", []))
         refs.extend(support.get("citation_refs", []))
         refs.extend(support.get("citation_check_refs", []))
         refs.extend(claim.get("ontology_context", {}).get("object_refs", []))
@@ -11769,6 +13111,26 @@ class LocalRuntimeStore:
             return {"status": "evidence_required"}
 
         policy = self._action_policy(mission, action_kind, risk, scope, connector)
+        if not (
+            claim.get("status") == "approved"
+            and claim.get("trust_state") == "approved"
+            and claim.get("statement_support", {}).get("semantic_support_verified") is True
+            and claim.get("authority", {}).get("can_drive_autonomous_action") is True
+        ):
+            policy = {
+                **policy,
+                "decision": "deny",
+                "policy": "action_source_claim_authority_required",
+                "reason_code": "CS_ACTION_CLAIM_AUTHORITY_REQUIRED",
+                "reason": "The Action can remain a review draft, but its source Claim has no semantic or action authority.",
+                "approval_required": True,
+                "can_execute_now": False,
+                "execution_status": "blocked_by_claim_authority",
+                "resolution_path": [
+                    "Review the Action Card without executing it.",
+                    "Complete statement-level semantic support review before granting Claim authority.",
+                ],
+            }
         expected_connector_calls = 1 if action_kind == "external_writeback" else 0
         ontology_refs = ontology_object_refs or claim.get("ontology_context", {}).get("object_refs", [])
         dry_run_base = {
@@ -12111,6 +13473,36 @@ class LocalRuntimeStore:
     def _action_lock_path(self, action_id: str) -> Path:
         return self.state_dir / "locks" / "actions" / f"{sha256_bytes(action_id.encode('utf-8'))}.lock"
 
+    def _action_claim_authority_denial(
+        self,
+        action: dict[str, Any],
+        scope: dict[str, str],
+    ) -> dict[str, Any] | None:
+        claim_id = str(action.get("source_claim_id") or "")
+        claim = self.get_claim(claim_id) if claim_id else None
+        claim_authorized = bool(
+            claim
+            and claim.get("scope") == scope
+            and claim.get("status") == "approved"
+            and claim.get("trust_state") == "approved"
+            and claim.get("statement_support", {}).get("semantic_support_verified") is True
+            and claim.get("authority", {}).get("can_drive_autonomous_action") is True
+        )
+        if claim_authorized:
+            return None
+        return self._action_execution_denial_policy(
+            action,
+            scope,
+            reason_code="CS_ACTION_CLAIM_AUTHORITY_REQUIRED",
+            policy="action_source_claim_authority_required",
+            reason="Action approval or execution requires a current semantically verified Claim with explicit action authority.",
+            resolution_path=[
+                "Keep this Action Card as a review draft.",
+                "Complete statement-level semantic support review before granting Claim authority.",
+                "Create a new governed Action only after the source Claim is currently authorized.",
+            ],
+        )
+
     def approve_action(self, action_id: str, scope: dict[str, str], approver: str = "owner") -> dict[str, Any]:
         lock_path = self._action_lock_path(action_id)
         lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -12129,6 +13521,27 @@ class LocalRuntimeStore:
             return {"status": "scope_denied", "resource_scope": action.get("scope")}
         if action.get("execution", {}).get("status") == "executed":
             return {"status": "already_executed", "action_card": action}
+        claim_authority_denial = self._action_claim_authority_denial(action, scope)
+        if claim_authority_denial is not None:
+            event = self.append_audit(
+                "action.approval.denied",
+                scope,
+                {"type": "action", "id": action_id},
+                {
+                    "mission_id": action.get("mission_id"),
+                    "reason_code": claim_authority_denial["reason_code"],
+                    "source_claim_id": action.get("source_claim_id"),
+                    "external_http_calls": 0,
+                    "provider_mutations": 0,
+                },
+            )
+            return {
+                "status": "policy_denied",
+                "reason_code": claim_authority_denial["reason_code"],
+                "policy_decision": claim_authority_denial,
+                "action_card": action,
+                "audit_event": event,
+            }
         if not action.get("approval", {}).get("required"):
             return {"status": "approval_not_required", "action_card": action}
         if not self._is_authorized_action_approver(approver, scope):
@@ -12691,6 +14104,40 @@ class LocalRuntimeStore:
             return {"status": "not_found"}
         if action.get("scope") != scope:
             return {"status": "scope_denied", "resource_scope": action.get("scope")}
+
+        claim_authority_denial = self._action_claim_authority_denial(action, scope)
+        if claim_authority_denial is not None:
+            safety_envelope = self._action_safety_envelope(
+                action,
+                scope,
+                status="denied",
+                reason_code=claim_authority_denial["reason_code"],
+                policy_decision=claim_authority_denial,
+            )
+            event = self.append_audit(
+                "action.execution.denied",
+                scope,
+                {"type": "action", "id": action_id},
+                {
+                    "mission_id": action.get("mission_id"),
+                    "source_claim_id": action.get("source_claim_id"),
+                    "policy": claim_authority_denial["policy"],
+                    "reason": claim_authority_denial["reason"],
+                    "reason_code": claim_authority_denial["reason_code"],
+                    "resolution_path": claim_authority_denial["resolution_path"],
+                    "action_safety_envelope_id": safety_envelope["action_safety_envelope_id"],
+                    "external_http_calls": 0,
+                    "provider_mutations": 0,
+                },
+            )
+            return {
+                "status": "policy_denied",
+                "reason_code": claim_authority_denial["reason_code"],
+                "policy_decision": claim_authority_denial,
+                "action_safety_envelope": safety_envelope,
+                "action_card": action,
+                "audit_event": event,
+            }
 
         mission = self.get_mission(action["mission_id"])
         if mission is None:
@@ -13894,7 +15341,90 @@ class LocalRuntimeStore:
         )
         return {"release_report_validation": report, "audit_event": event}
 
+    def _artifact_identity_for_ingest(
+        self,
+        checksum: str,
+        size_bytes: int,
+        scope: dict[str, str],
+    ) -> tuple[str, dict[str, Any] | None, dict[str, Any] | None]:
+        def record_identity_valid(record: dict[str, Any], artifact_id: str) -> bool:
+            return bool(
+                record.get("artifact_id") == artifact_id
+                and record.get("checksum_sha256") == checksum
+                and record.get("content_identity") == {"algorithm": "sha256", "value": checksum}
+                and record.get("original_storage_ref") == f"sha256:{checksum}"
+                and record.get("original_size_bytes") == size_bytes
+                and record.get("scope") == scope
+            )
+
+        canonical_id = f"art_{checksum}"
+        try:
+            canonical = self._get_artifact_unchecked(canonical_id, scope)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            return canonical_id, None, {
+                "status": "integrity_failed",
+                "reason": "canonical_artifact_record_unreadable",
+                "artifact_id": canonical_id,
+            }
+        if canonical is not None:
+            if not record_identity_valid(canonical, canonical_id):
+                return canonical_id, None, {
+                    "status": "integrity_failed",
+                    "reason": "canonical_artifact_identity_mismatch",
+                    "artifact_id": canonical_id,
+                }
+            return canonical_id, canonical, None
+
+        legacy_id = f"art_{checksum[:16]}"
+        try:
+            legacy = self._get_artifact_unchecked(legacy_id, scope)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            return legacy_id, None, {
+                "status": "integrity_failed",
+                "reason": "legacy_artifact_record_unreadable",
+                "artifact_id": legacy_id,
+            }
+        if legacy is not None and legacy.get("checksum_sha256") == checksum:
+            if not record_identity_valid(legacy, legacy_id):
+                return legacy_id, None, {
+                    "status": "integrity_failed",
+                    "reason": "legacy_artifact_identity_mismatch",
+                    "artifact_id": legacy_id,
+                }
+            return legacy_id, legacy, None
+        return canonical_id, None, None
+
+    def _artifact_lock_path(self, checksum: str, scope: dict[str, str]) -> Path:
+        lock_key = sha256_bytes(f"{scope_key(scope)}:{checksum}".encode("utf-8"))
+        return self.state_dir / "locks" / "artifacts" / f"{lock_key}.lock"
+
     def ingest_text_artifact(
+        self,
+        text: str,
+        scope: dict[str, str],
+        *,
+        source_type: str,
+        source_ref: str,
+        trust: str = "untrusted",
+    ) -> dict[str, Any]:
+        checksum = sha256_bytes(text.encode("utf-8"))
+        lock_path = self._artifact_lock_path(checksum, scope)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with _artifact_thread_lock(lock_path):
+            with lock_path.open("a+") as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    return self._ingest_text_artifact_locked(
+                        text,
+                        scope,
+                        source_type=source_type,
+                        source_ref=source_ref,
+                        trust=trust,
+                    )
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def _ingest_text_artifact_locked(
         self,
         text: str,
         scope: dict[str, str],
@@ -13905,7 +15435,9 @@ class LocalRuntimeStore:
     ) -> dict[str, Any]:
         data = text.encode("utf-8")
         checksum = sha256_bytes(data)
-        artifact_id = f"art_{checksum[:16]}"
+        artifact_id, existing, identity_error = self._artifact_identity_for_ingest(checksum, len(data), scope)
+        if identity_error is not None:
+            return identity_error
         original_storage_ref = f"sha256:{checksum}"
         raw_text = data.decode("utf-8", errors="replace")
         untrusted_text_sources = {"user_paste", "conversation_turn"}
@@ -13923,12 +15455,15 @@ class LocalRuntimeStore:
             "authority_expanded": False,
         }
         original_path = self.original_dir / checksum
-        self.original_dir.mkdir(parents=True, exist_ok=True)
-        if not original_path.exists():
-            original_path.write_bytes(data)
+        original_storage_status = store_content_atomically(
+            original_path,
+            data,
+            checksum_sha256=checksum,
+        )
 
-        existing = self.get_artifact(artifact_id, scope)
         if existing and existing.get("scope") == scope:
+            updated = dict(existing)
+            record_changed = False
             trust_downgraded = False
             if effective_trust == "untrusted" and (
                 existing.get("trust_state") != "untrusted"
@@ -13937,17 +15472,18 @@ class LocalRuntimeStore:
                 or existing.get("source", {}).get("type") != source_type
                 or existing.get("source", {}).get("ref") != source_ref
             ):
-                updated = dict(existing)
                 source_history = list(updated.get("source_history", [])) if isinstance(updated.get("source_history"), list) else []
                 if isinstance(updated.get("source"), dict):
                     source_history.append(updated["source"])
-                updated["trust_state"] = "untrusted"
-                updated["safety"] = safety
-                updated["source"] = {
+                source_observation = {
                     "type": source_type,
                     "ref": source_ref,
                     "ingested_at": utc_now(),
                 }
+                source_history.append(source_observation)
+                updated["trust_state"] = "untrusted"
+                updated["safety"] = safety
+                updated["source"] = source_observation
                 updated["source_history"] = source_history[-8:]
                 updated.setdefault("provenance", {}).setdefault("transformations", [])
                 transformations = updated["provenance"]["transformations"]
@@ -13955,9 +15491,33 @@ class LocalRuntimeStore:
                     transformations.append("trust_forced_untrusted")
                 if "source_rebound_to_untrusted_text" not in transformations:
                     transformations.append("source_rebound_to_untrusted_text")
+                trust_downgraded = True
+                record_changed = True
+            resolved_representation = self._resolved_derived_representation(updated)
+            legacy_representation = bool(
+                resolved_representation
+                and resolved_representation[0].get("schema_version") == "cs.derived_representation.legacy.v1"
+            )
+            if resolved_representation is None or legacy_representation:
+                redacted_text = redact_text(raw_text)
+                updated["derived"] = self._create_derived_representation(
+                    artifact_id=artifact_id,
+                    artifact_checksum_sha256=checksum,
+                    text=redacted_text,
+                    redacted=redacted_text != raw_text,
+                )
+                transformations = updated.setdefault("provenance", {}).setdefault("transformations", [])
+                transformation = (
+                    "derived_representation_migrated"
+                    if legacy_representation
+                    else "derived_representation_repaired"
+                )
+                if transformation not in transformations:
+                    transformations.append(transformation)
+                record_changed = True
+            if record_changed:
                 _write_json(self.artifact_path(artifact_id, scope), updated)
                 existing = updated
-                trust_downgraded = True
             event = self.append_audit(
                 "artifact.deduplicated",
                 scope,
@@ -13970,6 +15530,7 @@ class LocalRuntimeStore:
                     "trust_forced_untrusted": trust_forced_untrusted,
                     "trust_downgraded": trust_downgraded,
                     "unsafe_instruction_detected": safety["unsafe_instruction_detected"],
+                    "original_storage_status": original_storage_status,
                 },
             )
             return {
@@ -13982,10 +15543,12 @@ class LocalRuntimeStore:
 
         now = utc_now()
         redacted_text = redact_text(raw_text)
-        derived_text_ref = f"derived/{artifact_id}.txt"
-        derived_path = self.artifact_dir / derived_text_ref
-        derived_path.parent.mkdir(parents=True, exist_ok=True)
-        derived_path.write_text(redacted_text)
+        derived = self._create_derived_representation(
+            artifact_id=artifact_id,
+            artifact_checksum_sha256=checksum,
+            text=redacted_text,
+            redacted=redacted_text != raw_text,
+        )
         transformations = ["hash_calculated", "original_preserved", "derived_text_created"]
         if trust_forced_untrusted:
             transformations.append("trust_forced_untrusted")
@@ -14006,12 +15569,7 @@ class LocalRuntimeStore:
                 "ref": source_ref,
                 "ingested_at": now,
             },
-            "derived": {
-                "status": "ready",
-                "media_type": "text/plain",
-                "text_ref": derived_text_ref,
-                "redacted": redacted_text != raw_text,
-            },
+            "derived": derived,
             "provenance": {
                 "created_at": now,
                 "lineage_from": None,
@@ -14031,6 +15589,8 @@ class LocalRuntimeStore:
                 "unsafe_instruction_detected": safety["unsafe_instruction_detected"],
                 "effective_trust": effective_trust,
                 "trust_forced_untrusted": trust_forced_untrusted,
+                "derived_representation_id": derived.get("derived_representation_id"),
+                "original_storage_status": original_storage_status,
             },
         )
         return {
@@ -14063,6 +15623,8 @@ class LocalRuntimeStore:
             source_ref=conversation_id,
             trust="untrusted",
         )
+        if artifact_result.get("status") == "integrity_failed":
+            return artifact_result
         artifact = artifact_result["artifact"]
         artifact_safety = artifact.get("safety", {}) if isinstance(artifact, dict) else {}
         unsafe_instruction_detected = artifact_safety.get("unsafe_instruction_detected") is True
@@ -14277,6 +15839,7 @@ class LocalRuntimeStore:
                     scope,
                     query=question,
                     evidence_bundle_id=None,
+                    evidence_revision_sha256=str(snapshot.get("result_revision_sha256") or ""),
                     model_provider=model_provider,
                     embedding_model=embedding_model,
                     ollama_base_url=ollama_base_url,
@@ -14356,7 +15919,9 @@ class LocalRuntimeStore:
                         for ref in (
                             f"artifact:{chunk.get('artifact_id')}",
                             f"evidence_chunk:{chunk.get('evidence_chunk_id')}",
+                            str(chunk.get("derived_representation_ref") or ""),
                         )
+                        if ref
                     ],
                 }
             )
@@ -14504,21 +16069,71 @@ class LocalRuntimeStore:
         trust: str,
         lineage_from: str | None,
     ) -> dict[str, Any]:
-        media_type = normalize_media_type(media_type, filename)
-        checksum = sha256_bytes(data)
-        artifact_id = f"art_{checksum[:16]}"
-        original_storage_ref = f"sha256:{checksum}"
-        original_path = self.original_dir / checksum
-        self.original_dir.mkdir(parents=True, exist_ok=True)
-        if not original_path.exists():
-            original_path.write_bytes(data)
-
         scope = {
             "tenant_id": tenant_id,
             "owner_id": owner_id,
             "namespace_id": namespace_id,
             "workspace_id": workspace_id,
         }
+        lock_path = self._artifact_lock_path(sha256_bytes(data), scope)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with _artifact_thread_lock(lock_path):
+            with lock_path.open("a+") as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    return self._ingest_artifact_bytes_locked(
+                        data,
+                        filename=filename,
+                        tenant_id=tenant_id,
+                        owner_id=owner_id,
+                        namespace_id=namespace_id,
+                        workspace_id=workspace_id,
+                        source=source,
+                        source_ref=source_ref,
+                        source_path=source_path,
+                        media_type=media_type,
+                        derived_mode=derived_mode,
+                        trust=trust,
+                        lineage_from=lineage_from,
+                    )
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def _ingest_artifact_bytes_locked(
+        self,
+        data: bytes,
+        *,
+        filename: str,
+        tenant_id: str,
+        owner_id: str,
+        namespace_id: str,
+        workspace_id: str,
+        source: str,
+        source_ref: str | None = None,
+        source_path: str | None = None,
+        media_type: str,
+        derived_mode: str,
+        trust: str,
+        lineage_from: str | None,
+    ) -> dict[str, Any]:
+        media_type = normalize_media_type(media_type, filename)
+        checksum = sha256_bytes(data)
+        scope = {
+            "tenant_id": tenant_id,
+            "owner_id": owner_id,
+            "namespace_id": namespace_id,
+            "workspace_id": workspace_id,
+        }
+        artifact_id, existing, identity_error = self._artifact_identity_for_ingest(checksum, len(data), scope)
+        if identity_error is not None:
+            return identity_error
+        original_storage_ref = f"sha256:{checksum}"
+        original_path = self.original_dir / checksum
+        original_storage_status = store_content_atomically(
+            original_path,
+            data,
+            checksum_sha256=checksum,
+        )
         observed_at = utc_now()
         source_observation = {
             "type": source,
@@ -14543,7 +16158,6 @@ class LocalRuntimeStore:
             "external_http_calls": 0,
             "authority_expanded": False,
         }
-        existing = self.get_artifact(artifact_id, scope)
         if existing and existing.get("scope") == scope:
             updated = dict(existing)
             source_history = list(updated.get("source_history", [])) if isinstance(updated.get("source_history"), list) else []
@@ -14570,27 +16184,34 @@ class LocalRuntimeStore:
                     transformations.append("source_rebound_to_untrusted_upload")
             derived = updated.get("derived") if isinstance(updated.get("derived"), dict) else {}
             derived_status = str(derived.get("status") or "").lower()
-            if derived_status in {"deferred", "unsupported"} and media_type.startswith("text/"):
-                try:
-                    later_text = data.decode("utf-8")
-                except UnicodeDecodeError:
-                    later_text = ""
-                if later_text and "\x00" not in later_text:
-                    redacted_text = redact_text(later_text)
-                    derived_text_ref = f"derived/{artifact_id}.txt"
-                    derived_path = self.artifact_dir / derived_text_ref
-                    derived_path.parent.mkdir(parents=True, exist_ok=True)
-                    derived_path.write_text(redacted_text)
-                    updated["media_type"] = media_type
-                    updated["derived"] = {
-                        "status": "ready",
-                        "media_type": "text/plain",
-                        "text_ref": derived_text_ref,
-                        "redacted": redacted_text != later_text,
-                    }
-                    transformations = updated.setdefault("provenance", {}).setdefault("transformations", [])
-                    if "derived_text_created_from_later_observation" not in transformations:
-                        transformations.append("derived_text_created_from_later_observation")
+            resolved_representation = self._resolved_derived_representation(updated)
+            legacy_representation = bool(
+                resolved_representation
+                and resolved_representation[0].get("schema_version") == "cs.derived_representation.legacy.v1"
+            )
+            representation_missing = derived_status == "ready" and (
+                resolved_representation is None or legacy_representation
+            )
+            if (derived_status in {"deferred", "unsupported"} or representation_missing) and media_type.startswith("text/"):
+                later_text = data.decode("utf-8", errors="replace")
+                redacted_text = redact_text(later_text)
+                updated["media_type"] = media_type
+                updated["derived"] = self._create_derived_representation(
+                    artifact_id=artifact_id,
+                    artifact_checksum_sha256=checksum,
+                    text=redacted_text,
+                    redacted=redacted_text != later_text,
+                )
+                transformations = updated.setdefault("provenance", {}).setdefault("transformations", [])
+                transformation = (
+                    "derived_representation_migrated"
+                    if legacy_representation
+                    else "derived_representation_repaired"
+                    if representation_missing
+                    else "derived_text_created_from_later_observation"
+                )
+                if transformation not in transformations:
+                    transformations.append(transformation)
             _write_json(self.artifact_path(artifact_id, scope), updated)
             event = self.append_audit(
                 "artifact.deduplicated",
@@ -14607,6 +16228,8 @@ class LocalRuntimeStore:
                     "trust_downgraded": trust_downgraded,
                     "unsafe_instruction_detected": updated.get("safety", {}).get("unsafe_instruction_detected", False),
                     "derived_status": updated.get("derived", {}).get("status"),
+                    "derived_representation_id": updated.get("derived", {}).get("derived_representation_id"),
+                    "original_storage_status": original_storage_status,
                 },
             )
             audit_events = [event]
@@ -14663,16 +16286,12 @@ class LocalRuntimeStore:
         else:
             raw_text = data.decode("utf-8", errors="replace")
             redacted_text = redact_text(raw_text)
-            derived_text_ref = f"derived/{artifact_id}.txt"
-            derived_path = self.artifact_dir / derived_text_ref
-            derived_path.parent.mkdir(parents=True, exist_ok=True)
-            derived_path.write_text(redacted_text)
-            derived = {
-                "status": "ready",
-                "media_type": "text/plain",
-                "text_ref": derived_text_ref,
-                "redacted": redacted_text != raw_text,
-            }
+            derived = self._create_derived_representation(
+                artifact_id=artifact_id,
+                artifact_checksum_sha256=checksum,
+                text=redacted_text,
+                redacted=redacted_text != raw_text,
+            )
             transformations.append("derived_text_created")
 
         source_record = source_observation
@@ -14710,6 +16329,8 @@ class LocalRuntimeStore:
                 "media_type": media_type,
                 "size_bytes": len(data),
                 "source_type": source,
+                "derived_representation_id": derived.get("derived_representation_id"),
+                "original_storage_status": original_storage_status,
             },
         )
         audit_events = [event]

--- a/packages/cornerstone_cli/scenarios.py
+++ b/packages/cornerstone_cli/scenarios.py
@@ -15600,6 +15600,13 @@ def verify_vs0_audit_ledger(root: Path) -> dict[str, Any]:
         root,
         ["claim", "approve", claim_id, "--state-dir", state_rel, "--json"],
     ) if claim_id else {}
+    claim_approval_payload = _payload(transcripts["claim_approve"])
+    claim_approval_denied = (
+        transcripts["claim_approve"].get("exit_code") == 4
+        and claim_approval_payload.get("status") == "failed"
+        and "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED" in _error_codes(transcripts["claim_approve"])
+        and bool(claim_approval_payload.get("audit_refs"))
+    )
     transcripts["egress_test"] = _run_cli_json(
         root,
         ["egress", "test", "--url", "https://example.invalid/audit-denied", "--state-dir", state_rel, "--json"],
@@ -15622,7 +15629,7 @@ def verify_vs0_audit_ledger(root: Path) -> dict[str, Any]:
         "evidence_bundle.created",
         "brief.created",
         "claim.draft.created",
-        "claim.approved",
+        "claim.approval.denied",
         "policy.egress.denied",
         "policy.sandbox_access.denied",
     }
@@ -15654,7 +15661,7 @@ def verify_vs0_audit_ledger(root: Path) -> dict[str, Any]:
         and _exit_ok(transcripts["bundle_create"])
         and _exit_ok(transcripts["brief_create"])
         and _exit_ok(transcripts["claim_create"])
-        and _exit_ok(transcripts["claim_approve"])
+        and claim_approval_denied
         and _policy_denied(transcripts["egress_test"], "CS_EGRESS_DENIED")
         and _policy_denied(transcripts["sandbox_test"], "CS_SANDBOX_ACCESS_DENIED")
         and clean_ok
@@ -15924,7 +15931,7 @@ def verify_vs0_claim_evidence(root: Path) -> dict[str, Any]:
         root,
         ["claim", "approve", evidence_claim_id, "--state-dir", state_rel, "--json"],
     ) if evidence_claim_id else {}
-    approved_claim = _payload(transcripts["evidence_claim_approve"]).get("claim", {})
+    post_approval_attempt_claim = _payload(transcripts["evidence_claim_approve"]).get("claim", {})
     transcripts["audit_verify"] = _run_cli_json(root, ["audit", "verify", "--state-dir", state_rel, "--json"])
 
     unsupported_approval_codes = _error_codes(transcripts["unsupported_claim_approve"])
@@ -15944,14 +15951,29 @@ def verify_vs0_claim_evidence(root: Path) -> dict[str, Any]:
         and "CS_CLAIM_SUPPORT_REQUIRED" in _error_codes(transcripts["unrelated_bundle_claim_approve"])
         and _payload(transcripts["unrelated_bundle_claim_approve"]).get("audit_refs")
     )
-    evidence_approved = (
-        _exit_ok(transcripts["evidence_claim_approve"])
-        and approved_claim.get("status") == "approved"
-        and approved_claim.get("trust_state") == "approved"
-        and approved_claim.get("authority", {}).get("can_publish_shared_truth") is True
-        and approved_claim.get("authority", {}).get("can_drive_autonomous_action") is False
-        and f"artifact:{artifact_id}" in approved_claim.get("evidence_bundle", {}).get("artifact_refs", [])
-        and _payload(transcripts["evidence_claim_approve"]).get("audit_refs")
+    evidence_approval_payload = _payload(transcripts["evidence_claim_approve"])
+    evidence_approval_codes = _error_codes(transcripts["evidence_claim_approve"])
+    evidence_support = (
+        evidence_claim.get("statement_support")
+        if isinstance(evidence_claim.get("statement_support"), dict)
+        else {}
+    )
+    post_approval_authority = (
+        post_approval_attempt_claim.get("authority")
+        if isinstance(post_approval_attempt_claim.get("authority"), dict)
+        else {}
+    )
+    semantic_approval_denied = (
+        transcripts["evidence_claim_approve"].get("exit_code") == 4
+        and evidence_approval_payload.get("status") == "failed"
+        and "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED" in evidence_approval_codes
+        and bool(evidence_approval_payload.get("audit_refs"))
+        and post_approval_attempt_claim.get("status") == "draft"
+        and post_approval_attempt_claim.get("trust_state") == "draft"
+        and all(
+            post_approval_authority.get(field) is False
+            for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+        )
     )
     audit_ok = _exit_ok(transcripts["audit_verify"]) and _payload(transcripts["audit_verify"]).get("audit_integrity", {}).get("status") == "success"
     claim_006_ok = (
@@ -15973,9 +15995,21 @@ def verify_vs0_claim_evidence(root: Path) -> dict[str, Any]:
         and _exit_ok(transcripts["search"])
         and _exit_ok(transcripts["bundle_create"])
         and _exit_ok(transcripts["evidence_claim_create"])
-        and evidence_claim.get("trust_state") == "evidence_backed"
+        and evidence_claim.get("status") == "draft"
+        and evidence_claim.get("trust_state") == "draft"
         and evidence_claim.get("evidence_bundle", {}).get("evidence_item_count", 0) > 0
-        and evidence_approved
+        and f"artifact:{artifact_id}" in evidence_claim.get("evidence_bundle", {}).get("artifact_refs", [])
+        and evidence_support.get("status") == "source_supported"
+        and evidence_support.get("statement_support_state") == "source_supported"
+        and evidence_support.get("source_support_state") == "passed"
+        and evidence_support.get("semantic_faithfulness_state") == "human_required"
+        and evidence_support.get("semantic_support_verified") is False
+        and evidence_support.get("approval_eligible") is False
+        and all(
+            evidence_claim.get("authority", {}).get(field) is False
+            for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+        )
+        and semantic_approval_denied
         and audit_ok
     )
 
@@ -15993,14 +16027,15 @@ def verify_vs0_claim_evidence(root: Path) -> dict[str, Any]:
         _row(
             "CS-CLAIM-007",
             "MUST_PASS",
-            "PASS" if claim_007_ok else "FAIL",
+            "HUMAN_REQUIRED" if claim_007_ok else "FAIL",
             [
                 "cornerstone claim approve <unsupported_claim_id> --json",
                 "cornerstone evidence bundle create --search-snapshot-id <snapshot_id> --json",
                 "cornerstone claim create --evidence-bundle-id <bundle_id> --json",
                 "cornerstone claim approve <evidence_claim_id> --json",
             ],
-            "Claim approval requires both an Evidence Bundle and revision-bound statement support; missing support is denied and a source-anchored Claim can be approved.",
+            "Automated prerequisites prove revision-bound source support and safe denial, but the canonical evidence-backed/approved Claim outcome remains open until statement-level semantic review can be recorded separately.",
+            owner="Human" if claim_007_ok else "AI",
         ),
     ]
     blocking = [row for row in rows if row["status"] != "PASS" and row["owner"] != "Human"]
@@ -16025,25 +16060,43 @@ def verify_vs0_claim_evidence(root: Path) -> dict[str, Any]:
             "unsupported_resolution_path": (unsupported_approval_payload.get("errors") or [{}])[0].get("resolution_path", []),
             "artifact_id": artifact_id,
             "evidence_bundle_id": bundle_id,
-            "evidence_claim_id": evidence_claim_id,
-            "evidence_claim_trust_state": evidence_claim.get("trust_state"),
-            "evidence_claim_statement_support": evidence_claim.get("statement_support"),
+            "source_supported_claim_id": evidence_claim_id,
+            "source_supported_claim_status": evidence_claim.get("status"),
+            "source_supported_claim_trust_state": evidence_claim.get("trust_state"),
+            "source_supported_claim_statement_support": evidence_support,
+            "source_supported_claim_authority": evidence_claim.get("authority"),
             "unrelated_bundle_claim_id": unrelated_bundle_claim_id,
             "unrelated_bundle_claim_trust_state": unrelated_bundle_claim.get("trust_state"),
             "unrelated_bundle_claim_support_state": unrelated_bundle_claim.get("statement_support", {}).get("status"),
             "unrelated_bundle_approval_error_codes": _error_codes(transcripts["unrelated_bundle_claim_approve"]),
-            "approved_claim_status": approved_claim.get("status"),
-            "approved_claim_trust_state": approved_claim.get("trust_state"),
-            "approved_claim_authority": approved_claim.get("authority"),
+            "semantic_approval_exit_code": transcripts["evidence_claim_approve"].get("exit_code"),
+            "semantic_approval_error_codes": evidence_approval_codes,
+            "post_approval_attempt_claim_status": post_approval_attempt_claim.get("status"),
+            "post_approval_attempt_claim_trust_state": post_approval_attempt_claim.get("trust_state"),
+            "post_approval_attempt_claim_authority": post_approval_authority,
             "audit_event_count": _payload(transcripts["audit_verify"]).get("audit_integrity", {}).get("event_count"),
         },
         "negative_evidence": {
             "unsupported_approval_allowed": 0 if unsupported_denied else 1,
             "unrelated_bundle_claim_approved": 0 if unrelated_bundle_denied else 1,
-            "evidence_claim_approval_blocked": 0 if evidence_approved else 1,
-            "autonomous_action_allowed_from_claim": int(bool(approved_claim.get("authority", {}).get("can_drive_autonomous_action", True))),
+            "source_match_promoted_to_authority": 0
+            if all(
+                evidence_claim.get("authority", {}).get(field) is False
+                for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+            )
+            else 1,
+            "semantic_approval_allowed_without_review": 0 if semantic_approval_denied else 1,
+            "autonomous_action_allowed_from_claim": int(
+                bool(post_approval_authority.get("can_drive_autonomous_action", True))
+            ),
         },
-        "human_required": [],
+        "human_required": [
+            {
+                "id": "CS-CLAIM-007-SEMANTIC-REVIEW",
+                "status": "HUMAN_REQUIRED",
+                "required_evidence": "A reviewer must judge the exact Claim statement against its cited spans and Evidence Bundle revision before any later owner-approval Interface may grant authority.",
+            }
+        ],
     }
 
 
@@ -17070,7 +17123,7 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
             "claim",
             "create",
             "--statement",
-            "Unsupported draft statement for trust ladder inspection.",
+            "Unsupported draft statement for authority-gate inspection.",
             "--state-dir",
             state_rel,
             "--json",
@@ -17124,8 +17177,7 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
         root,
         ["claim", "approve", evidence_claim_id, "--state-dir", state_rel, "--json"],
     ) if evidence_claim_id else {}
-    approved_claim = _payload(transcripts["evidence_claim_approve"]).get("claim", {})
-    transcripts["approved_claim_show"] = _run_cli_json(
+    transcripts["post_approval_attempt_claim_show"] = _run_cli_json(
         root,
         ["claim", "show", evidence_claim_id, "--state-dir", state_rel, "--json"],
     ) if evidence_claim_id else {}
@@ -17173,6 +17225,10 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
     ) if mission_id and evidence_claim_id else {}
     high_action = _payload(transcripts["high_action_propose"]).get("action_card", {})
     high_action_id = high_action.get("action_id", "")
+    transcripts["high_action_approve"] = _run_cli_json(
+        root,
+        ["action", "approve", high_action_id, "--state-dir", state_rel, "--json"],
+    ) if high_action_id else {}
     transcripts["high_action_execute_before_approval"] = _run_cli_json(
         root,
         ["action", "execute", high_action_id, "--state-dir", state_rel, "--json"],
@@ -17203,23 +17259,58 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
     first_viewer_item = viewer_items[0] if viewer_items else {}
 
     unsupported_show_claim = _payload(transcripts["unsupported_claim_show"]).get("claim", {})
-    evidence_show_claim = _payload(transcripts["evidence_claim_show"]).get("claim", {})
-    approved_show_claim = _payload(transcripts["approved_claim_show"]).get("claim", {})
-    trust_states = {
-        "draft": unsupported_show_claim.get("trust_state"),
-        "evidence_backed": evidence_show_claim.get("trust_state"),
-        "approved": approved_show_claim.get("trust_state"),
+    source_supported_show_claim = _payload(transcripts["evidence_claim_show"]).get("claim", {})
+    post_approval_attempt_show_claim = _payload(transcripts["post_approval_attempt_claim_show"]).get("claim", {})
+    source_support = (
+        source_supported_show_claim.get("statement_support")
+        if isinstance(source_supported_show_claim.get("statement_support"), dict)
+        else {}
+    )
+    post_approval_support = (
+        post_approval_attempt_show_claim.get("statement_support")
+        if isinstance(post_approval_attempt_show_claim.get("statement_support"), dict)
+        else {}
+    )
+    claim_states = {
+        "unsupported_draft": unsupported_show_claim.get("trust_state"),
+        "source_supported_draft": source_supported_show_claim.get("trust_state"),
+        "post_semantic_gate_draft": post_approval_attempt_show_claim.get("trust_state"),
     }
-    trust_authority = {
-        "draft": unsupported_show_claim.get("authority"),
-        "evidence_backed": evidence_show_claim.get("authority"),
-        "approved": approved_show_claim.get("authority"),
+    claim_authority = {
+        "unsupported_draft": unsupported_show_claim.get("authority"),
+        "source_supported_draft": source_supported_show_claim.get("authority"),
+        "post_semantic_gate_draft": post_approval_attempt_show_claim.get("authority"),
     }
+    semantic_approval_payload = _payload(transcripts["evidence_claim_approve"])
+    semantic_approval_denied = (
+        transcripts["evidence_claim_approve"].get("exit_code") == 4
+        and semantic_approval_payload.get("status") == "failed"
+        and "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED" in _error_codes(transcripts["evidence_claim_approve"])
+        and bool(semantic_approval_payload.get("audit_refs"))
+    )
+    action_policy = high_action.get("policy_decision") if isinstance(high_action.get("policy_decision"), dict) else {}
+    action_approval_payload = _payload(transcripts["high_action_approve"])
+    action_approval_errors = action_approval_payload.get("errors", [])
+    action_approval_denied = (
+        transcripts["high_action_approve"].get("exit_code") == 8
+        and action_approval_payload.get("status") == "denied"
+        and isinstance(action_approval_errors, list)
+        and any(
+            error.get("code") == "CS_ACTION_APPROVAL_DENIED"
+            and error.get("reason_code") == "CS_ACTION_CLAIM_AUTHORITY_REQUIRED"
+            for error in action_approval_errors
+            if isinstance(error, dict)
+        )
+        and bool(action_approval_payload.get("policy_decision_refs"))
+        and bool(action_approval_payload.get("audit_refs"))
+    )
 
     denial_transcript_names = [
         "egress_test",
         "sandbox_test",
         "unsupported_claim_approve",
+        "evidence_claim_approve",
+        "high_action_approve",
         "high_action_execute_before_approval",
     ]
     denial_examples: dict[str, dict[str, Any]] = {}
@@ -17276,19 +17367,35 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
     claim_005_ok = (
         _exit_ok(transcripts["unsupported_claim_show"])
         and _exit_ok(transcripts["evidence_claim_show"])
-        and _exit_ok(transcripts["approved_claim_show"])
-        and trust_states == {"draft": "draft", "evidence_backed": "evidence_backed", "approved": "approved"}
-        and trust_authority["draft"].get("can_be_approved") is False
-        and trust_authority["evidence_backed"].get("can_be_approved") is True
-        and trust_authority["evidence_backed"].get("can_publish_shared_truth") is False
-        and trust_authority["approved"].get("can_publish_shared_truth") is True
-        and trust_authority["approved"].get("can_drive_autonomous_action") is False
+        and _exit_ok(transcripts["post_approval_attempt_claim_show"])
+        and claim_states
+        == {
+            "unsupported_draft": "draft",
+            "source_supported_draft": "draft",
+            "post_semantic_gate_draft": "draft",
+        }
+        and source_supported_show_claim.get("status") == "draft"
+        and source_support.get("status") == "source_supported"
+        and source_support.get("statement_support_state") == "source_supported"
+        and source_support.get("semantic_faithfulness_state") == "human_required"
+        and source_support.get("semantic_support_verified") is False
+        and source_support.get("approval_eligible") is False
+        and post_approval_support.get("status") == "source_supported"
+        and post_approval_support.get("semantic_faithfulness_state") == "human_required"
+        and post_approval_attempt_show_claim.get("status") == "draft"
+        and semantic_approval_denied
+        and all(isinstance(authority, dict) for authority in claim_authority.values())
+        and all(
+            authority.get(field) is False
+            for authority in claim_authority.values()
+            for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+        )
     )
     claim_008_ok = (
         _exit_ok(transcripts["evidence_claim_show"])
         and _exit_ok(transcripts["evidence_view"])
-        and evidence_show_claim.get("evidence_bundle", {}).get("evidence_bundle_id") == bundle_id
-        and f"artifact:{artifact_id}" in evidence_show_claim.get("evidence_bundle", {}).get("artifact_refs", [])
+        and source_supported_show_claim.get("evidence_bundle", {}).get("evidence_bundle_id") == bundle_id
+        and f"artifact:{artifact_id}" in source_supported_show_claim.get("evidence_bundle", {}).get("artifact_refs", [])
         and first_viewer_item.get("artifact_id") == artifact_id
         and first_viewer_item.get("original", {}).get("storage_ref", "").startswith("sha256:")
         and first_viewer_item.get("derived", {}).get("text_ref", "").startswith("derived/")
@@ -17300,6 +17407,12 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
         _policy_denied(transcripts["egress_test"], "CS_EGRESS_DENIED")
         and _policy_denied(transcripts["sandbox_test"], "CS_SANDBOX_ACCESS_DENIED")
         and transcripts["unsupported_claim_approve"].get("exit_code") == 4
+        and semantic_approval_denied
+        and action_policy.get("decision") == "deny"
+        and action_policy.get("reason_code") == "CS_ACTION_CLAIM_AUTHORITY_REQUIRED"
+        and action_policy.get("execution_status") == "blocked_by_claim_authority"
+        and action_policy.get("can_execute_now") is False
+        and action_approval_denied
         and _action_policy_blocked(transcripts["high_action_execute_before_approval"])
         and missing_resolution_paths == 0
         and denial_without_audit == 0
@@ -17316,13 +17429,14 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
         _row(
             "CS-CLAIM-005",
             "MUST_PASS",
-            "PASS" if claim_005_ok and audit_ok else "FAIL",
+            "HUMAN_REQUIRED" if claim_005_ok and audit_ok else "FAIL",
             [
-                "cornerstone claim show <draft_claim_id> --json",
-                "cornerstone claim show <evidence_backed_claim_id> --json",
-                "cornerstone claim show <approved_claim_id> --json",
+                "cornerstone claim show <unsupported_draft_claim_id> --json",
+                "cornerstone claim show <source_supported_draft_claim_id> --json",
+                "cornerstone claim approve <source_supported_draft_claim_id> --json",
             ],
-            "Claim detail examples show Draft, Evidence-backed, and Approved trust states with authority limits for each state.",
+            "Current Claim detail safely distinguishes unsupported and source-supported Drafts, but the canonical Draft/Evidence-backed/Approved examples remain open until semantic review and later owner approval can be recorded.",
+            owner="Human" if claim_005_ok and audit_ok else "AI",
         ),
         _row(
             "CS-CLAIM-008",
@@ -17346,9 +17460,11 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
                 "cornerstone egress test --json",
                 "cornerstone sandbox test --json",
                 "cornerstone claim approve <unsupported_claim_id> --json",
+                "cornerstone claim approve <source_supported_claim_id> --json",
+                "cornerstone action approve <claim_blocked_action_id> --json",
                 "cornerstone action execute <high_risk_action_id> --json",
             ],
-            "Denied egress, sandbox access, unsupported claim approval, and high-risk action execution all include cause, safe resolution path, and audit evidence.",
+            "Denied egress, sandbox access, unsupported or semantically unreviewed Claim approval, and Claim-blocked Action approval/execution all include cause, safe resolution path, and audit evidence.",
         ),
     ]
     blocking = [row for row in rows if row["status"] != "PASS" and row["owner"] != "Human"]
@@ -17378,8 +17494,15 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
             "artifact_related_mission_ids": [item.get("mission_id") for item in related_missions if isinstance(item, dict)],
             "artifact_derived_status": artifact_detail.get("derived", {}).get("status"),
             "artifact_original_storage_ref": artifact_detail.get("original_storage_ref"),
-            "trust_states": trust_states,
-            "trust_authority": trust_authority,
+            "claim_states": claim_states,
+            "claim_authority": claim_authority,
+            "source_supported_statement_support": source_support,
+            "post_approval_attempt_statement_support": post_approval_support,
+            "semantic_approval_exit_code": transcripts["evidence_claim_approve"].get("exit_code"),
+            "semantic_approval_error_codes": _error_codes(transcripts["evidence_claim_approve"]),
+            "action_policy": action_policy,
+            "action_approval_exit_code": transcripts["high_action_approve"].get("exit_code"),
+            "action_execution_exit_code": transcripts["high_action_execute_before_approval"].get("exit_code"),
             "evidence_viewer_id": evidence_viewer.get("evidence_viewer_id"),
             "evidence_viewer_item_count": len(viewer_items),
             "evidence_viewer_first_item": first_viewer_item,
@@ -17391,12 +17514,39 @@ def verify_vs0_detail_surfaces(root: Path) -> dict[str, Any]:
             + int(bool(org_boundary.get("implicit_cross_namespace_context"))),
             "artifact_detail_missing_related_claims": 0 if related_claims else 1,
             "artifact_detail_missing_related_missions": 0 if related_missions else 1,
-            "trust_ladder_missing_states": 0 if trust_states == {"draft": "draft", "evidence_backed": "evidence_backed", "approved": "approved"} else 1,
+            "legacy_authority_state_exposed": 0
+            if claim_states
+            == {
+                "unsupported_draft": "draft",
+                "source_supported_draft": "draft",
+                "post_semantic_gate_draft": "draft",
+            }
+            and all(isinstance(authority, dict) for authority in claim_authority.values())
+            and all(
+                authority.get(field) is False
+                for authority in claim_authority.values()
+                for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+            )
+            else 1,
+            "source_match_promoted_to_authority": 0
+            if source_support.get("status") == "source_supported"
+            and source_supported_show_claim.get("trust_state") == "draft"
+            and source_support.get("approval_eligible") is False
+            else 1,
+            "claim_blocked_action_approval_or_execution_allowed": 0
+            if action_approval_denied and _action_policy_blocked(transcripts["high_action_execute_before_approval"])
+            else 1,
             "evidence_viewer_missing_sources": 0 if claim_008_ok else 1,
             "policy_denials_missing_resolution_path": missing_resolution_paths,
             "policy_denials_without_audit": denial_without_audit,
         },
-        "human_required": [],
+        "human_required": [
+            {
+                "id": "CS-CLAIM-005-SEMANTIC-REVIEW",
+                "status": "HUMAN_REQUIRED",
+                "required_evidence": "Review the exact source-supported Claim statement against its cited spans before any future authority-granting Interface is used.",
+            }
+        ],
     }
 
 
@@ -17486,6 +17636,14 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
     promoted_scope = promoted_claim.get("scope", {})
     promoted_source = promoted_claim.get("source_conversation", {})
     promoted_provenance = promoted_claim.get("provenance", {})
+    promoted_support = (
+        promoted_claim.get("statement_support")
+        if isinstance(promoted_claim.get("statement_support"), dict)
+        else {}
+    )
+    promoted_authority = (
+        promoted_claim.get("authority") if isinstance(promoted_claim.get("authority"), dict) else {}
+    )
     answer = _payload(transcripts["unsupported_answer"]).get("answer", {})
     required_setup = conversation.get("required_setup", {})
     suggested_outputs = conversation.get("suggested_outputs", [])
@@ -17518,7 +17676,12 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
         and first_use_duration_ms <= 5000
         and setup_required_count == 0
         and brief_id.startswith("brief_")
-        and promoted_claim.get("trust_state") == "evidence_backed"
+        and promoted_claim.get("status") == "draft"
+        and promoted_claim.get("trust_state") == "draft"
+        and promoted_support.get("status") == "source_supported"
+        and promoted_support.get("semantic_faithfulness_state") == "human_required"
+        and promoted_support.get("semantic_support_verified") is False
+        and promoted_support.get("approval_eligible") is False
     )
     claim_001_ok = (
         common_path_ok
@@ -17549,7 +17712,19 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
         and promoted_source.get("source_artifact_ref") == f"artifact:{source_artifact_id}"
         and promoted_evidence.get("evidence_bundle_id") == bundle_id
         and _scope_complete(promoted_scope)
-        and promoted_claim.get("trust_state") == "evidence_backed"
+        and promoted_claim.get("status") == "draft"
+        and promoted_claim.get("trust_state") == "draft"
+        and promoted_support.get("status") == "source_supported"
+        and promoted_support.get("statement_support_state") == "source_supported"
+        and promoted_support.get("source_support_state") == "passed"
+        and promoted_support.get("semantic_faithfulness_state") == "human_required"
+        and promoted_support.get("semantic_support_verified") is False
+        and promoted_support.get("approval_eligible") is False
+        and bool(promoted_authority)
+        and all(
+            promoted_authority.get(field) is False
+            for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+        )
         and promoted_provenance.get("created_from") == "conversation.promote"
         and _payload(transcripts["conversation_promote_claim"]).get("audit_refs")
     )
@@ -17574,7 +17749,7 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
                 "cornerstone brief create --evidence-bundle-id <id> --json",
                 "cornerstone conversation promote <conversation_id> --kind claim --json",
             ],
-            "The first useful path starts from messy conversation input, reaches a source-linked fallback brief, and manually promotes a draft/evidence-backed claim without connector, model-provider, ontology, or organization setup.",
+            "The first useful path starts from messy conversation input, reaches a source-linked fallback brief, and manually promotes a source-supported Draft Claim without connector, model-provider, ontology, or organization setup; semantic authority remains human-required.",
         ),
         _row(
             "CS-CLAIM-001",
@@ -17595,7 +17770,7 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
             "MUST_PASS",
             "PASS" if claim_004_ok else "FAIL",
             ["cornerstone conversation promote <conversation_id> --kind claim --evidence-bundle-id <id> --json"],
-            "Manual conversation promotion creates a durable claim with source conversation ref, source artifact ref, evidence bundle, owner namespace, trust state, provenance, and audit refs.",
+            "Manual conversation promotion creates a durable source-supported Draft Claim with source conversation ref, source artifact ref, evidence bundle, owner namespace, provenance, audit refs, and no semantic/action authority.",
         ),
         _row(
             "CS-CLAIM-009",
@@ -17631,7 +17806,10 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
             "brief_presented_as_fact": brief.get("presented_as_fact"),
             "brief_model_provider": brief.get("model_provider"),
             "promoted_claim_id": promoted_claim_id,
+            "promoted_claim_status": promoted_claim.get("status"),
             "promoted_claim_trust_state": promoted_claim.get("trust_state"),
+            "promoted_claim_statement_support": promoted_support,
+            "promoted_claim_authority": promoted_authority,
             "promoted_claim_source_conversation": promoted_source,
             "promoted_claim_provenance": promoted_provenance,
             "suggested_output_types": sorted(suggested_types),
@@ -17656,10 +17834,25 @@ def verify_vs0_conversation_onboarding(root: Path) -> dict[str, Any]:
             "brief_presented_as_fact": int(bool(brief.get("presented_as_fact"))),
             "promoted_objects_without_scope": 0 if _scope_complete(promoted_scope) else 1,
             "promoted_objects_without_evidence": 0 if promoted_evidence.get("evidence_bundle_id") and promoted_evidence.get("artifact_refs") else 1,
+            "promoted_source_match_granted_authority": 0
+            if promoted_support.get("status") == "source_supported"
+            and promoted_claim.get("trust_state") == "draft"
+            and bool(promoted_authority)
+            and all(
+                promoted_authority.get(field) is False
+                for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+            )
+            else 1,
             "unsupported_assertions_presented_as_fact": int(bool(answer.get("presented_as_fact", True))),
             "real_external_http_calls": 0,
         },
-        "human_required": [],
+        "human_required": [
+            {
+                "id": "CS-CLAIM-004-SEMANTIC-REVIEW",
+                "status": "HUMAN_REQUIRED",
+                "required_evidence": "Review the promoted Claim's exact statement against its cited spans and Evidence Bundle revision before any later authority grant.",
+            }
+        ],
     }
 
 
@@ -23957,6 +24150,14 @@ def _report_passes(report: dict[str, Any], scenario_ids: set[str]) -> bool:
     return report.get("status") == "success" and scenario_ids <= passed
 
 
+def _report_has_status(report: dict[str, Any], scenario_id: str, status: str) -> bool:
+    return any(
+        row.get("id") == scenario_id and row.get("status") == status
+        for row in report.get("scenario_results", [])
+        if isinstance(row, dict)
+    )
+
+
 def _negative_zero(report: dict[str, Any]) -> bool:
     negative = report.get("negative_evidence", {})
     return isinstance(negative, dict) and all(value == 0 for value in negative.values() if isinstance(value, int))
@@ -23973,14 +24174,32 @@ def verify_vs0_regression_guardrails(root: Path) -> dict[str, Any]:
     claim_evidence = claim_report.get("claim_evidence", {})
     audit_evidence = audit_report.get("audit_evidence", {})
     security_policy_evidence = security_policy_report.get("security_policy_evidence", {})
+    source_supported_support = claim_evidence.get("source_supported_claim_statement_support", {})
+    source_supported_authority = claim_evidence.get("source_supported_claim_authority", {})
+    post_approval_authority = claim_evidence.get("post_approval_attempt_claim_authority", {})
 
     reg_016_ok = (
-        _report_passes(claim_report, {"CS-CLAIM-006", "CS-CLAIM-007"})
+        _report_passes(claim_report, {"CS-CLAIM-006"})
+        and _report_has_status(claim_report, "CS-CLAIM-007", "HUMAN_REQUIRED")
         and _report_passes(search_evidence_report, {"CS-ARCH-008", "CS-ARCH-009", "CS-UND-001"})
         and claim_evidence.get("unsupported_claim_trust_state") == "draft"
-        and claim_evidence.get("evidence_claim_trust_state") == "evidence_backed"
-        and claim_evidence.get("approved_claim_trust_state") == "approved"
+        and claim_evidence.get("source_supported_claim_status") == "draft"
+        and claim_evidence.get("source_supported_claim_trust_state") == "draft"
+        and source_supported_support.get("status") == "source_supported"
+        and source_supported_support.get("semantic_faithfulness_state") == "human_required"
+        and source_supported_support.get("semantic_support_verified") is False
+        and source_supported_support.get("approval_eligible") is False
+        and claim_evidence.get("post_approval_attempt_claim_status") == "draft"
+        and claim_evidence.get("post_approval_attempt_claim_trust_state") == "draft"
+        and bool(source_supported_authority)
+        and bool(post_approval_authority)
+        and all(
+            authority.get(field) is False
+            for authority in (source_supported_authority, post_approval_authority)
+            for field in ("can_be_approved", "can_publish_shared_truth", "can_drive_autonomous_action")
+        )
         and "CS_CLAIM_EVIDENCE_REQUIRED" in claim_evidence.get("unsupported_approval_error_codes", [])
+        and "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED" in claim_evidence.get("semantic_approval_error_codes", [])
         and _negative_zero(claim_report)
     )
     reg_017_ok = (
@@ -23993,7 +24212,8 @@ def verify_vs0_regression_guardrails(root: Path) -> dict[str, Any]:
         _report_passes(security_policy_report, {"CS-SEC-002", "CS-SEC-003"})
         and _report_passes(security_report, {"CS-SEC-007", "CS-SEC-008", "CS-REG-013"})
         and _report_passes(namespace_report, {"CS-NS-001", "CS-NS-003"})
-        and _report_passes(claim_report, {"CS-CLAIM-006", "CS-CLAIM-007"})
+        and _report_passes(claim_report, {"CS-CLAIM-006"})
+        and _report_has_status(claim_report, "CS-CLAIM-007", "HUMAN_REQUIRED")
         and security_policy_evidence.get("egress_external_http_calls") == 0
         and _negative_zero(security_policy_report)
         and _negative_zero(security_report)
@@ -24010,7 +24230,7 @@ def verify_vs0_regression_guardrails(root: Path) -> dict[str, Any]:
                 "cornerstone scenario verify vs0-claim-evidence --json",
                 "cornerstone scenario verify vs0-search-evidence --json",
             ],
-            "Evidence requirements and trust states remain visible through unsupported draft, evidence-backed claim, approved claim, and evidence bundle checks.",
+            "Evidence and authority gates remain visible: unsupported and source-supported Claims stay Draft, semantic review remains HUMAN_REQUIRED, and approval/shared-truth/action authority stays false.",
         ),
         _row(
             "CS-REG-017",
@@ -24038,11 +24258,17 @@ def verify_vs0_regression_guardrails(root: Path) -> dict[str, Any]:
             "status": claim_report.get("status"),
             "summary": claim_report.get("summary"),
             "negative_evidence": claim_report.get("negative_evidence"),
-            "trust_states": {
-                "unsupported": claim_evidence.get("unsupported_claim_trust_state"),
-                "evidence_backed": claim_evidence.get("evidence_claim_trust_state"),
-                "approved": claim_evidence.get("approved_claim_trust_state"),
+            "claim_states": {
+                "unsupported_draft": claim_evidence.get("unsupported_claim_trust_state"),
+                "source_supported_draft": claim_evidence.get("source_supported_claim_trust_state"),
+                "post_semantic_gate_draft": claim_evidence.get("post_approval_attempt_claim_trust_state"),
             },
+            "source_support_status": source_supported_support.get("status"),
+            "semantic_support_state": source_supported_support.get("semantic_faithfulness_state"),
+            "semantic_support_verified": source_supported_support.get("semantic_support_verified"),
+            "approval_error_codes": claim_evidence.get("semantic_approval_error_codes", []),
+            "source_supported_authority": source_supported_authority,
+            "post_approval_attempt_authority": post_approval_authority,
         },
         "audit_ledger": {
             "status": audit_report.get("status"),
@@ -24090,7 +24316,7 @@ def verify_vs0_regression_guardrails(root: Path) -> dict[str, Any]:
             "audit_guardrail_failed": 0 if reg_017_ok else 1,
             "security_guardrail_failed": 0 if reg_018_ok else 1,
         },
-        "human_required": [],
+        "human_required": claim_report.get("human_required", []),
     }
 
 

--- a/packages/cornerstone_cli/ui/styles.py
+++ b/packages/cornerstone_cli/ui/styles.py
@@ -317,6 +317,16 @@ button, input, textarea, select {{ font: inherit; }}
 .cs-help-menu[open] > summary,
 .cs-help-menu > summary:hover {{ border-color: var(--cs-color-border-strong); box-shadow: var(--cs-shadow-sm); }}
 .cs-help-menu > summary:focus-visible {{ border-color: var(--cs-color-border-focus); box-shadow: var(--cs-shadow-focus); }}
+.cs-help-glyph {{
+  display: block;
+  width: 20px;
+  height: 20px;
+  color: var(--cs-color-text-primary);
+  font-size: 20px;
+  font-weight: var(--cs-typography-weight-bold);
+  line-height: 20px;
+  text-align: center;
+}}
 .cs-help-popover {{
   position: absolute;
   z-index: 4;

--- a/scripts/capture_vs4_h01_ui_recovery_screenshots.py
+++ b/scripts/capture_vs4_h01_ui_recovery_screenshots.py
@@ -108,7 +108,7 @@ DESKTOP_ROUTES = [
         "name": "claims-desktop",
         "route": "/claims",
         "surface": "claims",
-        "required_text": ["Claims that need source support", "Review posture", "Trust ladder"],
+        "required_text": ["Claims under review", "Semantic review needed", "Review posture", "Trust ladder"],
         "required_selectors": ["[data-product-surface='claims']", ".cs-collection-workbench", ".cs-collection-list"],
     },
     {
@@ -230,10 +230,10 @@ DETAIL_ROUTES = [
         "kind": "actions",
         "id_key": "action_id",
         "surface": "action-detail",
-        "required_text": ["Action preview", "Proposed change", "Why this action", "Policy and boundary"],
+        "required_text": ["Blocked action", "Action blocked", "Why this action", "Policy and boundary"],
         "required_selectors": [
             "[data-product-surface='action-detail'][data-execution-mode][data-real-external-http-calls]",
-            "[data-action-preview='true']",
+            "[data-action-policy-blocked='true']",
             "[data-action-approval-state]",
         ],
     },

--- a/tests/scenario/test_product_ui_routes.py
+++ b/tests/scenario/test_product_ui_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import hashlib
+import io
 import json
 import re
 import shutil
@@ -12,6 +13,7 @@ import unittest
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -31,6 +33,7 @@ from cornerstone_cli.artifacts import (
 )
 from cornerstone_cli.acceptance import VS4_PRODUCT_FORBIDDEN_RE, _vs4_product_journey_timeline_evidence
 from cornerstone_cli.briefing import RuntimeModelConfig
+from cornerstone_cli.main import main as cli_main
 from cornerstone_cli.product_access import ProductAccessApplication, SearchRequest
 from cornerstone_cli.product_runtime import DEFAULT_SCOPE, make_server
 from cornerstone_cli.runtime import LocalRuntimeStore
@@ -196,7 +199,11 @@ class ProductUiRoutesTest(unittest.TestCase):
                 self.assertIn("Global search", html)
                 self.assertIn("Search sources, Briefs, decisions, and actions", html)
                 self.assertIn('aria-label="Search the active workspace"', html)
-                self.assertIn('aria-label="Open Review inbox with 0 items"', html)
+                if route in {"/", "/inbox"}:
+                    self.assertIn('aria-label="Open Review inbox with 0 items"', html)
+                else:
+                    self.assertIn('aria-label="Open Review inbox"', html)
+                    self.assertNotIn('aria-label="Open Review inbox with 0 items"', html)
                 self.assertIn('<details class="cs-help-menu">', html)
                 self.assertIn('aria-label="Open help"', html)
                 self.assertIn('<span class="cs-help-glyph" aria-hidden="true">?</span>', html)
@@ -446,8 +453,128 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertNotIn(secret, html)
         self.assertNotIn(secret, reused)
         self.assertIn("[REDACTED]", html)
-        self.assertNotIn("Search snapshot unavailable", reused)
+        self.assertIn("Search snapshot unavailable", reused)
         self.assertNotIn(secret, LocalRuntimeStore(self.state_dir).audit_path.read_text())
+
+    def test_snapshot_reuse_binds_to_exact_query_hash_and_fails_closed_without_revision_binding(self) -> None:
+        store = LocalRuntimeStore(self.state_dir)
+        access = ProductAccessApplication(store)
+        first_secret = "sk-snapshotfirst12345678"
+        second_secret = "sk-snapshotsecond12345678"
+
+        created = access.search(
+            SearchRequest(query=first_secret, scope=dict(DEFAULT_SCOPE), mode="workspace")
+        )
+        snapshot = created["search_snapshot"]
+        snapshot_id = snapshot["search_snapshot_id"]
+        self.assertEqual(snapshot["query"], "[REDACTED]")
+
+        exact = access.search(
+            SearchRequest(
+                query=first_secret,
+                scope=dict(DEFAULT_SCOPE),
+                mode="workspace",
+                snapshot_id=snapshot_id,
+            )
+        )
+        collided_redaction = access.search(
+            SearchRequest(
+                query=second_secret,
+                scope=dict(DEFAULT_SCOPE),
+                mode="workspace",
+                snapshot_id=snapshot_id,
+            )
+        )
+        self.assertEqual(exact["status"], "success")
+        self.assertEqual(collided_redaction["status"], "snapshot_query_mismatch")
+
+        secret_legacy_path = store.search_snapshot_path(snapshot_id)
+        secret_legacy = dict(snapshot)
+        secret_legacy.pop("query_sha256")
+        secret_legacy_path.write_text(json.dumps(secret_legacy, indent=2, sort_keys=True) + "\n")
+        unverifiable_legacy_secret = access.search(
+            SearchRequest(
+                query=first_secret,
+                scope=dict(DEFAULT_SCOPE),
+                mode="workspace",
+                snapshot_id=snapshot_id,
+            )
+        )
+        self.assertEqual(unverifiable_legacy_secret["status"], "integrity_failed")
+
+        legacy = access.search(
+            SearchRequest(query="legacy exact query", scope=dict(DEFAULT_SCOPE), mode="workspace")
+        )["search_snapshot"]
+        legacy_path = store.search_snapshot_path(legacy["search_snapshot_id"])
+        legacy.pop("query_sha256")
+        legacy_path.write_text(json.dumps(legacy, indent=2, sort_keys=True) + "\n")
+        legacy_exact = access.search(
+            SearchRequest(
+                query="legacy exact query",
+                scope=dict(DEFAULT_SCOPE),
+                mode="workspace",
+                snapshot_id=legacy["search_snapshot_id"],
+            )
+        )
+        legacy_mismatch = access.search(
+            SearchRequest(
+                query="legacy different query",
+                scope=dict(DEFAULT_SCOPE),
+                mode="workspace",
+                snapshot_id=legacy["search_snapshot_id"],
+            )
+        )
+        self.assertEqual(legacy_exact["status"], "integrity_failed")
+        self.assertEqual(legacy_mismatch["status"], "integrity_failed")
+
+    def test_tampered_evidence_readers_return_structured_http_integrity_failures(self) -> None:
+        store = LocalRuntimeStore(self.state_dir)
+        self.create_source_stack()
+        snapshot = store.search("vendor renewal", **DEFAULT_SCOPE)["snapshot"]
+        snapshot_path = store.search_snapshot_path(snapshot["search_snapshot_id"])
+        tampered_snapshot = json.loads(snapshot_path.read_text())
+        tampered_snapshot["results"][0]["snippet"] = "forged snapshot"
+        snapshot_path.write_text(json.dumps(tampered_snapshot, indent=2, sort_keys=True) + "\n")
+
+        snapshot_status, _, snapshot_raw = _request(
+            self.base_url,
+            f"/search-snapshots/{snapshot['search_snapshot_id']}?{urlencode(DEFAULT_SCOPE)}",
+            headers={"accept": "application/json"},
+        )
+        self.assertEqual(snapshot_status, 409)
+        self.assertEqual(
+            json.loads(snapshot_raw)["errors"][0]["code"],
+            "CS_SEARCH_SNAPSHOT_INTEGRITY_FAILED",
+        )
+
+        clean_snapshot = store.search("vendor renewal", **DEFAULT_SCOPE)["snapshot"]
+        bundle = store.create_evidence_bundle(clean_snapshot["search_snapshot_id"], dict(DEFAULT_SCOPE))["bundle"]
+        bundle_path = store.evidence_bundle_path(bundle["evidence_bundle_id"])
+        tampered_bundle = json.loads(bundle_path.read_text())
+        tampered_bundle["evidence_items"][0]["snippet"] = "forged bundle"
+        bundle_path.write_text(json.dumps(tampered_bundle, indent=2, sort_keys=True) + "\n")
+
+        bundle_status, _, bundle_raw = _request(
+            self.base_url,
+            f"/evidence-bundles/{bundle['evidence_bundle_id']}?{urlencode(DEFAULT_SCOPE)}",
+            headers={"accept": "application/json"},
+        )
+        self.assertEqual(bundle_status, 409)
+        self.assertEqual(
+            json.loads(bundle_raw)["errors"][0]["code"],
+            "CS_EVIDENCE_BUNDLE_INTEGRITY_FAILED",
+        )
+        brief_status, _, brief_raw = _request(
+            self.base_url,
+            "/briefs",
+            method="POST",
+            payload={**DEFAULT_SCOPE, "evidence_bundle_id": bundle["evidence_bundle_id"]},
+        )
+        self.assertEqual(brief_status, 409)
+        self.assertEqual(
+            json.loads(brief_raw)["errors"][0]["code"],
+            "CS_BRIEF_EVIDENCE_INTEGRITY_FAILED",
+        )
 
     def test_icon_assets_have_explicit_success_and_not_found_contracts(self) -> None:
         status, content_type, body = _request_bytes(
@@ -514,6 +641,181 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertEqual(event["details"]["filters"], {})
         self.assertIn(f'data-page-audit-ref="audit:{event["event_id"]}"', html)
         self.assertNotIn(secret, store.audit_path.read_text())
+
+    def test_collection_routes_only_read_the_record_families_they_project(self) -> None:
+        class ProjectionSpyStore:
+            def __init__(self) -> None:
+                self.core_reads: list[str] = []
+
+            def _artifact_records(self, _: dict[str, str]) -> list[dict[str, Any]]:
+                self.core_reads.append("artifact")
+                return []
+
+            def _brief_records(self, _: dict[str, str]) -> list[dict[str, Any]]:
+                self.core_reads.append("brief")
+                return []
+
+            def _claim_records(self, _: dict[str, str]) -> list[dict[str, Any]]:
+                self.core_reads.append("claim")
+                return []
+
+            def _action_records(self, _: dict[str, str]) -> list[dict[str, Any]]:
+                self.core_reads.append("action")
+                return []
+
+            def _memory_records(self, _: dict[str, str]) -> list[dict[str, Any]]:
+                self.core_reads.append("memory")
+                return []
+
+            def _all_audit_events(self) -> list[dict[str, Any]]:
+                return []
+
+            def verify_audit(self) -> dict[str, Any]:
+                return {"status": "success", "event_count": 0, "errors": []}
+
+            def append_audit(
+                self,
+                _event_type: str,
+                _scope: dict[str, str],
+                _subject: dict[str, str],
+                _details: dict[str, Any],
+            ) -> dict[str, str]:
+                return {"event_id": "audit_projection"}
+
+        expected_reads = {
+            "/": {"artifact", "brief", "claim", "action", "memory"},
+            "/search": set(),
+            "/artifacts": {"artifact", "brief", "claim", "action"},
+            "/briefs": {"artifact", "brief"},
+            "/claims": {"artifact", "brief", "claim"},
+            "/actions": {"artifact", "brief", "claim", "action"},
+            "/inbox": {"artifact", "brief", "claim", "action", "memory"},
+            "/audit": set(),
+        }
+        for route, expected in expected_reads.items():
+            with self.subTest(route=route):
+                store = ProjectionSpyStore()
+                html = product_ui.render_product_page(ROOT, store, DEFAULT_SCOPE, route, {})
+                self.assertEqual(set(store.core_reads), expected)
+                self.assertEqual(len(store.core_reads), len(expected))
+                self.assertIn('data-product-shell="cornerstone"', html)
+
+    def test_detail_read_returns_non_disclosing_503_when_audit_receipt_fails(self) -> None:
+        secret = "Detail record text must never render after its read audit fails."
+        created = LocalRuntimeStore(self.state_dir).ingest_text_artifact(
+            secret,
+            DEFAULT_SCOPE,
+            source_type="user_paste",
+            source_ref="detail-audit-failure",
+            trust="untrusted",
+        )["artifact"]
+
+        with mock.patch.object(LocalRuntimeStore, "append_audit", side_effect=OSError("ledger offline")):
+            status, content_type, html = _request(
+                self.base_url,
+                f"/artifacts/{created['artifact_id']}?view=html",
+                headers={"accept": "text/html"},
+            )
+
+        self.assertEqual(status, 503)
+        self.assertIn("text/html", content_type)
+        self.assertIn('data-product-state="access-audit-unavailable"', html)
+        self.assertIn("Access unavailable", html)
+        self.assertNotIn(secret, html)
+        self.assertNotIn(str(created["artifact_id"]), html)
+        self.assertNotIn("ledger offline", html)
+
+    def test_surface_integrity_failures_are_structured_for_artifact_and_conversation_paths(self) -> None:
+        store = LocalRuntimeStore(self.state_dir)
+
+        identity_text = "Surface adapters must reject altered Artifact identity metadata."
+        artifact = store.ingest_text_artifact(
+            identity_text,
+            DEFAULT_SCOPE,
+            source_type="user_paste",
+            source_ref="surface-integrity",
+            trust="untrusted",
+        )["artifact"]
+        artifact_path = store.artifact_path(artifact["artifact_id"], DEFAULT_SCOPE)
+        altered_artifact = json.loads(artifact_path.read_text())
+        altered_artifact["original_size_bytes"] += 1
+        artifact_path.write_text(json.dumps(altered_artifact, indent=2, sort_keys=True) + "\n")
+
+        api_status, _, api_raw = _request(self.base_url, f"/artifacts/{artifact['artifact_id']}")
+        self.assertEqual(api_status, 409)
+        self.assertEqual(
+            json.loads(api_raw)["errors"][0]["code"],
+            "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+        )
+
+        def run_cli(*arguments: str) -> tuple[int, dict[str, Any]]:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                exit_code = cli_main([*arguments, "--state-dir", str(self.state_dir), "--json"])
+            return exit_code, json.loads(output.getvalue())
+
+        show_exit, show_payload = run_cli("artifact", "show", artifact["artifact_id"])
+        self.assertEqual(show_exit, 5)
+        self.assertEqual(show_payload["errors"][0]["code"], "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED")
+
+        start_exit, start_payload = run_cli("conversation", "start", "--message", identity_text)
+        self.assertEqual(start_exit, 5)
+        self.assertEqual(start_payload["errors"][0]["code"], "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED")
+
+        source = store.ingest_text_artifact(
+            "Conversation promotion needs verified renewal evidence.",
+            DEFAULT_SCOPE,
+            source_type="user_paste",
+            source_ref="conversation-promotion-integrity",
+            trust="untrusted",
+        )["artifact"]
+        snapshot = store.search("verified renewal evidence", **DEFAULT_SCOPE)["snapshot"]
+        bundle = store.create_evidence_bundle(snapshot["search_snapshot_id"], dict(DEFAULT_SCOPE))["bundle"]
+        claim = store.create_claim_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            "Conversation promotion needs verified renewal evidence.",
+            dict(DEFAULT_SCOPE),
+        )["claim"]
+        conversation = store.start_conversation("Clean promotion request", dict(DEFAULT_SCOPE))["conversation"]
+        derived_path = store.artifact_dir / bundle["evidence_items"][0]["derived_storage_ref"]
+        derived_path.write_text("forged derived text")
+
+        approve_exit, approve_payload = run_cli("claim", "approve", claim["claim_id"])
+        self.assertEqual(approve_exit, 5)
+        self.assertEqual(approve_payload["errors"][0]["code"], "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED")
+
+        promote_args = (
+            "conversation",
+            "promote",
+            conversation["conversation_id"],
+            "--statement",
+            "Conversation promotion needs verified renewal evidence.",
+            "--evidence-bundle-id",
+            bundle["evidence_bundle_id"],
+        )
+        promote_exit, promote_payload = run_cli(*promote_args)
+        self.assertEqual(promote_exit, 5)
+        self.assertEqual(
+            promote_payload["errors"][0]["code"],
+            "CS_CONVERSATION_PROMOTION_EVIDENCE_INTEGRITY_FAILED",
+        )
+
+        promote_status, _, promote_raw = _request(
+            self.base_url,
+            f"/conversations/{conversation['conversation_id']}/promote",
+            method="POST",
+            payload={
+                **DEFAULT_SCOPE,
+                "statement": "Conversation promotion needs verified renewal evidence.",
+                "evidence_bundle_id": bundle["evidence_bundle_id"],
+            },
+        )
+        self.assertEqual(promote_status, 409)
+        self.assertEqual(
+            json.loads(promote_raw)["errors"][0]["code"],
+            "CS_CONVERSATION_PROMOTION_EVIDENCE_INTEGRITY_FAILED",
+        )
+        self.assertEqual(source["artifact_id"], bundle["evidence_items"][0]["artifact_id"])
 
     def test_browser_file_upload_preserves_exact_bytes_and_content_identity(self) -> None:
         scope_query = urlencode(DEFAULT_SCOPE)
@@ -1035,11 +1337,13 @@ class ProductUiRoutesTest(unittest.TestCase):
 
         artifacts_html = self.fetch_product_html("/artifacts")
         briefs_html = self.fetch_product_html("/briefs")
+        inbox_html = self.fetch_product_html("/inbox")
         artifact_detail = self.fetch_product_html(f"/artifacts/{artifact['artifact_id']}?view=html")
         brief_detail = self.fetch_product_html(f"/briefs/{brief['brief_id']}?view=html")
 
         self.assertNotIn(source_text, artifacts_html)
         self.assertNotIn(brief_title, briefs_html)
+        self.assertNotIn(brief_title, inbox_html)
         self.assertIn('data-product-surface="owner-record"', artifact_detail)
         self.assertIn('data-product-surface="owner-record"', brief_detail)
         self.assertNotIn(source_text, artifact_detail)
@@ -1186,6 +1490,28 @@ class ProductUiRoutesTest(unittest.TestCase):
         not_found_names = {spec["name"] for spec in not_found_specs}
         interaction_specs = capture_vs4.interaction_route_specs()
         interaction_names = {spec["name"] for spec in interaction_specs}
+        specs_by_name = {spec["name"]: spec for spec in specs}
+
+        self.assertEqual(
+            specs_by_name["claims-desktop"]["required_text"],
+            ["Claims under review", "Semantic review needed", "Review posture", "Trust ladder"],
+        )
+        self.assertEqual(
+            specs_by_name["action-detail-desktop"]["required_text"],
+            ["Blocked action", "Action blocked", "Why this action", "Policy and boundary"],
+        )
+        self.assertIn(
+            "[data-action-policy-blocked='true']",
+            specs_by_name["action-detail-desktop"]["required_selectors"],
+        )
+        self.assertNotIn(
+            "[data-action-preview='true']",
+            specs_by_name["action-detail-desktop"]["required_selectors"],
+        )
+        long_ref = "artifact:art_" + ("a" * 64)
+        breakable_ref = product_ui._breakable_ref(long_ref)
+        self.assertIn("<wbr>", breakable_ref)
+        self.assertEqual(breakable_ref.replace("<wbr>", ""), long_ref)
 
         for route in [
             "/",
@@ -1510,12 +1836,12 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertIn("Back to Claims", claim_html)
         self.assertIn("Decision statement", claim_html)
         self.assertIn('data-source-support-attached="true"', claim_html)
-        self.assertIn('data-approval-eligible="true"', claim_html)
+        self.assertIn('data-approval-eligible="false"', claim_html)
         self.assertIn("Supporting evidence", claim_html)
-        self.assertIn("Ready for an owner decision", claim_html)
-        self.assertIn('id="cs-approve-claim-button"', claim_html)
-        self.assertIn('id="cs-claim-approval-dialog"', claim_html)
-        self.assertIn(f'postJson("/claims/" + encodeURIComponent(claimId) + "/approve"', claim_html)
+        self.assertIn("Approval is not available", claim_html)
+        self.assertIn("Semantic review required", claim_html)
+        self.assertNotIn('id="cs-approve-claim-button"', claim_html)
+        self.assertNotIn('id="cs-claim-approval-dialog"', claim_html)
         self.assertNotIn('href="/inbox">Request review', claim_html)
         self.assertNotRegex(claim_html, r'<a[^>]*>\s*Save\s*</a>')
         self.assert_product_surface_is_clean(claim_html)
@@ -1526,15 +1852,15 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertIn("Back to Actions", action_html)
         self.assertIn("Open history", action_html)
         self.assertNotIn('href="/claims">Back to claims', action_html)
-        self.assertIn("Action preview", action_html)
+        self.assertIn("Blocked action", action_html)
         self.assertIn('data-approval-required="true"', action_html)
-        self.assertIn('data-approval-eligible="true"', action_html)
-        self.assertIn('data-real-external-http-calls="0"', action_html)
-        self.assertIn("Proposed change", action_html)
-        self.assertIn("Approval required", action_html)
-        self.assertIn('id="cs-approve-action-button"', action_html)
-        self.assertIn('id="cs-action-approval-dialog"', action_html)
-        self.assertIn(f'postJson("/actions/" + encodeURIComponent(actionId) + "/approve"', action_html)
+        self.assertIn('data-approval-eligible="false"', action_html)
+        self.assertIn('data-real-external-http-calls="not-recorded"', action_html)
+        self.assertIn("Action blocked", action_html)
+        self.assertIn("Policy blocked", action_html)
+        self.assertIn("Approval", action_html)
+        self.assertNotIn('id="cs-approve-action-button"', action_html)
+        self.assertNotIn('id="cs-action-approval-dialog"', action_html)
         self.assertIn("Sources", action_html)
         self.assertIn("Policy and boundary", action_html)
         self.assertNotIn('href="/inbox">Request approval</a>', action_html)
@@ -1549,9 +1875,11 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assert_product_surface_is_clean(artifacts_html)
 
         claims_html = self.fetch_product_html("/claims")
-        self.assertIn("Claims that need source support", claims_html)
+        self.assertIn("Claims under review", claims_html)
         self.assertIn("Review posture", claims_html)
         self.assertIn("Trust ladder", claims_html)
+        self.assertIn("Semantic review", claims_html)
+        self.assertNotIn("Evidence-backed", claims_html)
         self.assert_product_surface_is_clean(claims_html)
 
         actions_html = self.fetch_product_html("/actions")
@@ -1605,14 +1933,14 @@ class ProductUiRoutesTest(unittest.TestCase):
         audit_count = len(store._all_audit_events())
 
         html = self.fetch_product_html(
-            f"/inbox?lane=approval-requests&item=action%3A{action_id}"
+            f"/inbox?lane=policy-blocked&item=action%3A{action_id}"
         )
 
         self.assertEqual(len(store._all_audit_events()), audit_count + 1)
-        self.assertIn('data-inbox-lane="approval-requests"', html)
+        self.assertIn('data-inbox-lane="policy-blocked"', html)
         self.assertIn(f'data-selected-item="action:{action_id}"', html)
-        self.assertIn('class="cs-inbox-tab is-active" href="/inbox?lane=approval-requests" aria-current="page"', html)
-        self.assertIn(f'href="/inbox?lane=approval-requests&amp;item=action%3A{action_id}#selected-work"', html)
+        self.assertIn('class="cs-inbox-tab is-active" href="/inbox?lane=policy-blocked" aria-current="page"', html)
+        self.assertIn(f'href="/inbox?lane=policy-blocked&amp;item=action%3A{action_id}#selected-work"', html)
         self.assertIn("Prepare the renewal decision follow-up", html)
         self.assertIn("Continue review", html)
         self.assertIn(f'href="/actions/{action_id}?view=html"', html)
@@ -1667,33 +1995,40 @@ class ProductUiRoutesTest(unittest.TestCase):
     def test_home_ask_prepares_fallback_brief_from_non_conversation_sources(self) -> None:
         artifact_id, _, _ = self.create_source_stack()
         home = self.fetch_product_html("/")
-        self.assertIn('excluded_source_types: ["conversation_turn"]', home)
-        self.assertLess(home.index('postJson("/search"'), home.index('postJson("/conversations"'))
+        self.assertNotIn('postJson("/search"', home)
+        self.assertIn("const sourceSnapshot = answered.search_snapshot || {};", home)
         self.assertIn("Keyword-summary Brief prepared", home)
         self.assertIn("Brief preparation was blocked because the Ask text contained unsafe instructions", home)
 
+        snapshots_before = {
+            path.name for path in (self.state_dir / "search" / "snapshots").glob("*.json")
+        }
         conversation_status, _, conversation_raw = _request(
             self.base_url,
             "/conversations",
             method="POST",
-            payload={**DEFAULT_SCOPE, "message": "What does the vendor renewal source say?"},
+            payload={**DEFAULT_SCOPE, "message": "vendor renewal"},
         )
         self.assertEqual(conversation_status, 200)
         conversation = json.loads(conversation_raw)["conversation"]
         conversation_artifact_id = conversation["source_artifact_id"]
 
-        search_status, _, search_raw = _request(
+        answer_status, _, answer_raw = _request(
             self.base_url,
-            "/search",
+            f"/conversations/{conversation['conversation_id']}/answers",
             method="POST",
-            payload={
-                **DEFAULT_SCOPE,
-                "query": "vendor renewal",
-                "excluded_source_types": ["conversation_turn"],
-            },
+            payload={**DEFAULT_SCOPE, "question": "vendor renewal"},
         )
-        self.assertEqual(search_status, 200)
-        snapshot = json.loads(search_raw)["search_snapshot"]
+        self.assertEqual(answer_status, 200)
+        answer_payload = json.loads(answer_raw)
+        snapshot = answer_payload["search_snapshot"]
+        snapshots_after = {
+            path.name for path in (self.state_dir / "search" / "snapshots").glob("*.json")
+        }
+        self.assertEqual(
+            snapshots_after - snapshots_before,
+            {f"{snapshot['search_snapshot_id']}.json"},
+        )
         result_artifact_ids = {row.get("artifact_id") for row in snapshot["results"]}
         self.assertEqual(snapshot["excluded_source_types"], ["conversation_turn"])
         self.assertIn(artifact_id, result_artifact_ids)
@@ -2069,12 +2404,14 @@ class ProductUiRoutesTest(unittest.TestCase):
 
         action_html = self.fetch_product_html(f"/actions/{action_id}?view=html")
         self.assertIn('data-execution-mode="Local / Mock / Draft"', action_html)
+        self.assertIn('data-product-state="blocked"', action_html)
         self.assertIn("Why this action", action_html)
         self.assertIn("Open supporting Claim", action_html)
-        self.assertIn("Proposed change", action_html)
+        self.assertIn("Action blocked", action_html)
+        self.assertIn("Policy blocked", action_html)
         self.assertIn("Policy and boundary", action_html)
         self.assertIn("Planned external calls", action_html)
-        self.assertIn('id="cs-approve-action-button"', action_html)
+        self.assertNotIn('id="cs-approve-action-button"', action_html)
         self.assertNotIn('href="/inbox">Request approval</a>', action_html)
 
         denied_status, _, denied_raw = _request(
@@ -2086,6 +2423,8 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertEqual(denied_status, 403)
         denial = json.loads(denied_raw)
         self.assertEqual(denial["status"], "denied")
+        self.assertEqual(denial["errors"][0]["code"], "CS_ACTION_POLICY_DENIED")
+        self.assertEqual(denial["errors"][0]["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
         self.assertTrue(denial["errors"][0]["resolution_path"])
 
         denied_html = self.fetch_product_html(f"/actions/{action_id}?view=html")
@@ -2283,7 +2622,7 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertIn("Open source Brief", claim_html)
         self.assertIn("History", claim_html)
 
-    def test_claim_approval_denial_and_approved_page_report_durable_state(self) -> None:
+    def test_claim_approval_denials_report_evidence_and_semantic_boundaries(self) -> None:
         unsupported_status, _, unsupported_raw = _request(
             self.base_url,
             "/claims",
@@ -2338,25 +2677,32 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertEqual(claim_status, 200)
         supported_claim = json.loads(claim_raw)["claim"]
         claim_id = supported_claim["claim_id"]
-        self.assertEqual(supported_claim["trust_state"], "evidence_backed")
-        self.assertEqual(supported_claim["statement_support"]["status"], "passed")
+        self.assertEqual(supported_claim["status"], "draft")
+        self.assertEqual(supported_claim["trust_state"], "draft")
+        self.assertEqual(supported_claim["statement_support"]["status"], "source_supported")
+        self.assertEqual(supported_claim["statement_support"]["source_support_state"], "passed")
         self.assertEqual(supported_claim["statement_support"]["citation_integrity_state"], "passed")
         self.assertTrue(supported_claim["statement_support"]["citation_refs"])
         self.assertTrue(supported_claim["statement_support"]["citation_check_refs"])
         self.assertEqual(supported_claim["statement_support"]["semantic_faithfulness_state"], "human_required")
-        approve_status, _, _ = _request(
+        self.assertFalse(supported_claim["statement_support"]["semantic_support_verified"])
+        self.assertFalse(supported_claim["authority"]["can_be_approved"])
+        approve_status, _, approve_raw = _request(
             self.base_url,
             f"/claims/{claim_id}/approve",
             method="POST",
             payload=dict(DEFAULT_SCOPE),
         )
-        self.assertEqual(approve_status, 200)
-        approved_html = self.fetch_product_html(f"/claims/{claim_id}?view=html")
-        self.assertIn("Approval recorded", approved_html)
-        self.assertIn('data-claim-approval-state="approved"', approved_html)
-        self.assertIn("Open Claim history", approved_html)
-        self.assertIn("This does not authorize an external action", approved_html)
-        self.assertNotIn('id="cs-approve-claim-button"', approved_html)
+        self.assertEqual(approve_status, 400)
+        approval = json.loads(approve_raw)
+        self.assertEqual(approval["errors"][0]["code"], "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED")
+        blocked_html = self.fetch_product_html(f"/claims/{claim_id}?view=html")
+        self.assertIn("Approval blocked", blocked_html)
+        self.assertIn('data-claim-approval-state="blocked"', blocked_html)
+        self.assertIn("Semantic review required", blocked_html)
+        self.assertIn("Semantic support and owner approval remain separate decisions", blocked_html)
+        self.assertNotIn("<h2>Approval recorded</h2>", blocked_html)
+        self.assertNotIn('id="cs-approve-claim-button"', blocked_html)
 
         show_status, show_content_type, _ = _request(self.base_url, f"/claims/{claim_id}", headers={"accept": "application/json"})
         self.assertEqual(show_status, 200)
@@ -2447,7 +2793,7 @@ class ProductUiRoutesTest(unittest.TestCase):
         )
         self.assertEqual(create_status, 200, create_raw)
         claim = json.loads(create_raw)["claim"]
-        self.assertEqual(claim["statement_support"]["status"], "passed")
+        self.assertEqual(claim["statement_support"]["status"], "source_supported")
 
         store = LocalRuntimeStore(self.state_dir)
         tampered = dict(claim)
@@ -2460,9 +2806,9 @@ class ProductUiRoutesTest(unittest.TestCase):
             method="POST",
             payload=dict(DEFAULT_SCOPE),
         )
-        self.assertEqual(approve_status, 400, approve_raw)
+        self.assertEqual(approve_status, 409, approve_raw)
         approval = json.loads(approve_raw)
-        self.assertEqual(approval["errors"][0]["code"], "CS_CLAIM_SUPPORT_REQUIRED")
+        self.assertEqual(approval["errors"][0]["code"], "CS_CLAIM_EVIDENCE_INTEGRITY_FAILED")
         persisted = store.get_claim(claim["claim_id"])
         self.assertEqual(persisted["status"], "draft")
         denial_events = [
@@ -2471,7 +2817,7 @@ class ProductUiRoutesTest(unittest.TestCase):
             if event.get("event_type") == "claim.approval.denied"
             and event.get("subject", {}).get("id") == claim["claim_id"]
         ]
-        self.assertEqual(denial_events[-1]["details"]["reason"], "statement_support_missing_or_stale")
+        self.assertEqual(denial_events[-1]["details"]["reason"], "claim_evidence_integrity_failed")
 
     def test_inbox_renders_validated_runtime_journey_without_mutating_read(self) -> None:
         _, bundle_id, _ = self.create_source_stack()
@@ -2684,7 +3030,7 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertEqual(len(store._all_audit_events()), audit_count)
         self.assertEqual(len(claim_ids), 2)
 
-    def test_executed_action_reports_durable_state_and_html_details_are_audited(self) -> None:
+    def test_claim_blocked_action_reports_durable_denial_and_html_details_are_audited(self) -> None:
         artifact_id, bundle_id, _ = self.create_source_stack()
         brief_status, _, brief_raw = _request(
             self.base_url,
@@ -2717,22 +3063,30 @@ class ProductUiRoutesTest(unittest.TestCase):
         )
         self.assertEqual(action_status, 200)
         action_id = json.loads(action_raw)["action_card"]["action_id"]
-        approve_status, _, _ = _request(
+        approve_status, _, approve_raw = _request(
             self.base_url,
             f"/actions/{action_id}/approve",
             method="POST",
             payload={**DEFAULT_SCOPE, "approver": "owner"},
         )
-        self.assertEqual(approve_status, 200)
+        self.assertEqual(approve_status, 403)
+        approve_error = json.loads(approve_raw)["errors"][0]
+        self.assertEqual(approve_error["code"], "CS_ACTION_APPROVAL_DENIED")
+        self.assertEqual(approve_error["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
         execute_status, _, execute_raw = _request(
             self.base_url,
             f"/actions/{action_id}/execute",
             method="POST",
             payload=dict(DEFAULT_SCOPE),
         )
-        self.assertEqual(execute_status, 200, execute_raw)
+        self.assertEqual(execute_status, 403, execute_raw)
+        execute_error = json.loads(execute_raw)["errors"][0]
+        self.assertEqual(execute_error["code"], "CS_ACTION_POLICY_DENIED")
+        self.assertEqual(execute_error["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
 
         store = LocalRuntimeStore(self.state_dir)
+        self.assertFalse(store.workflow_run_dir.exists())
+        self.assertFalse(store.action_result_dir.exists())
         audit_count_before_detail_reads = len(store._all_audit_events())
         detail_paths = [
             f"/artifacts/{artifact_id}?view=html",
@@ -2753,11 +3107,11 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.fetch_product_html(f"/briefs/{brief_id}?view=html")
         self.fetch_product_html(f"/claims/{claim_id}?view=html")
         action_html = self.fetch_product_html(f"/actions/{action_id}?view=html")
-        self.assertIn("Action result", action_html)
-        self.assertIn("Execution result", action_html)
-        self.assertIn('data-product-state="executed"', action_html)
-        self.assertIn('data-real-external-http-calls="0"', action_html)
-        self.assertIn("Approved by owner", action_html)
+        self.assertIn("Action blocked", action_html)
+        self.assertIn("Execution blocked", action_html)
+        self.assertIn('data-product-state="blocked"', action_html)
+        self.assertIn('data-real-external-http-calls="not-recorded"', action_html)
+        self.assertNotIn("Approved by owner", action_html)
         self.assertIn("Policy and boundary", action_html)
         self.assertIn("History", action_html)
         self.assertNotIn("Request approval", action_html)
@@ -2768,12 +3122,14 @@ class ProductUiRoutesTest(unittest.TestCase):
         actions_html = self.fetch_product_html("/actions")
         self.assertIn("Action records", actions_html)
         self.assertIn("Records", actions_html)
-        self.assertIn("Open result", actions_html)
-        self.assertIn("Recorded result", actions_html)
+        self.assertIn("Policy blocked", actions_html)
+        self.assertNotIn("Open result", actions_html)
+        self.assertNotIn("Recorded result", actions_html)
 
-        inbox_html = self.fetch_product_html("/inbox")
-        self.assertNotIn(f"/actions/{action_id}?view=html", inbox_html)
-        self.assertNotIn("Record a renewal follow-up", inbox_html)
+        inbox_html = self.fetch_product_html("/inbox?lane=policy-blocked")
+        self.assertIn(f"/actions/{action_id}?view=html", inbox_html)
+        self.assertIn("Record a renewal follow-up", inbox_html)
+        self.assertIn("Policy blocked", inbox_html)
 
         events_after_detail_reads = store._all_audit_events()
         detail_read_events = [

--- a/tests/scenario/test_product_ui_routes.py
+++ b/tests/scenario/test_product_ui_routes.py
@@ -198,6 +198,9 @@ class ProductUiRoutesTest(unittest.TestCase):
                 self.assertIn('aria-label="Search the active workspace"', html)
                 self.assertIn('aria-label="Open Review inbox with 0 items"', html)
                 self.assertIn('<details class="cs-help-menu">', html)
+                self.assertIn('aria-label="Open help"', html)
+                self.assertIn('<span class="cs-help-glyph" aria-hidden="true">?</span>', html)
+                self.assertNotIn('/assets/icons/help.svg', html)
                 self.assertIn('aria-label="Open local workspace settings"', html)
                 self.assertIn("cs-nav-count", html)
                 for label in ["Home", "Search", "Artifacts", "Claims", "Actions"]:
@@ -887,6 +890,8 @@ class ProductUiRoutesTest(unittest.TestCase):
         self.assertIn(".cs-search button { width: 44px; min-width: 44px; min-height: 44px;", css)
         self.assertIn(".cs-review-link:focus-visible { border-color: var(--cs-color-border-focus); box-shadow: var(--cs-shadow-focus); }", css)
         self.assertIn(".cs-help-menu > summary:focus-visible { border-color: var(--cs-color-border-focus); box-shadow: var(--cs-shadow-focus); }", css)
+        self.assertIn(".cs-help-glyph {", css)
+        self.assertIn("font-size: 20px;", css)
         self.assertRegex(css, re.compile(r"\.cs-icon-button \{.*?width: 44px;.*?height: 44px;", re.DOTALL))
         self.assertIn(".cs-status[hidden] { display: none; }", css)
         self.assertIn("@media (prefers-reduced-motion: reduce)", css)

--- a/tests/scenario/test_scaffold_cli.py
+++ b/tests/scenario/test_scaffold_cli.py
@@ -16350,19 +16350,38 @@ LocalRuntimeStore(state_dir).append_audit(
         payload = json.loads(result.stdout)
         self.assertEqual(payload["scenario_set"], "vs0-claim-evidence")
         self.assertEqual(payload["summary"]["blocking"], 0)
-        self.assertEqual(payload["summary"]["pass"], 2)
+        self.assertEqual(payload["summary"]["pass"], 1)
         self.assertEqual(payload["summary"]["product_feature_claims"], "PARTIAL_VS0_CLAIM_EVIDENCE_ONLY")
         self.assertEqual({row["id"] for row in payload["scenario_results"]}, {"CS-CLAIM-006", "CS-CLAIM-007"})
+        row_statuses = {row["id"]: row["status"] for row in payload["scenario_results"]}
+        self.assertEqual(row_statuses, {"CS-CLAIM-006": "PASS", "CS-CLAIM-007": "HUMAN_REQUIRED"})
         evidence = payload["claim_evidence"]
         self.assertEqual(evidence["unsupported_claim_trust_state"], "draft")
         self.assertEqual(evidence["unsupported_claim_show_evidence_refs"], [f"claim:{evidence['unsupported_claim_id']}"])
         self.assertEqual(evidence["unsupported_approval_exit_code"], 4)
         self.assertIn("CS_CLAIM_EVIDENCE_REQUIRED", evidence["unsupported_approval_error_codes"])
         self.assertTrue(evidence["unsupported_resolution_path"])
-        self.assertEqual(evidence["evidence_claim_trust_state"], "evidence_backed")
-        self.assertEqual(evidence["approved_claim_status"], "approved")
-        self.assertEqual(evidence["approved_claim_trust_state"], "approved")
-        self.assertFalse(evidence["approved_claim_authority"]["can_drive_autonomous_action"])
+        self.assertEqual(evidence["source_supported_claim_status"], "draft")
+        self.assertEqual(evidence["source_supported_claim_trust_state"], "draft")
+        support = evidence["source_supported_claim_statement_support"]
+        self.assertEqual(support["status"], "source_supported")
+        self.assertEqual(support["statement_support_state"], "source_supported")
+        self.assertEqual(support["source_support_state"], "passed")
+        self.assertEqual(support["semantic_faithfulness_state"], "human_required")
+        self.assertFalse(support["semantic_support_verified"])
+        self.assertFalse(support["approval_eligible"])
+        self.assertEqual(evidence["semantic_approval_exit_code"], 4)
+        self.assertIn("CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED", evidence["semantic_approval_error_codes"])
+        self.assertEqual(evidence["post_approval_attempt_claim_status"], "draft")
+        self.assertEqual(evidence["post_approval_attempt_claim_trust_state"], "draft")
+        for authority in (
+            evidence["source_supported_claim_authority"],
+            evidence["post_approval_attempt_claim_authority"],
+        ):
+            self.assertFalse(authority["can_be_approved"])
+            self.assertFalse(authority["can_publish_shared_truth"])
+            self.assertFalse(authority["can_drive_autonomous_action"])
+        self.assertEqual(payload["human_required"][0]["status"], "HUMAN_REQUIRED")
         for value in payload["negative_evidence"].values():
             self.assertEqual(value, 0)
 
@@ -16397,11 +16416,31 @@ LocalRuntimeStore(state_dir).append_audit(
         self.assertEqual(payload["summary"]["product_feature_claims"], "PARTIAL_VS0_REGRESSION_GUARDRAILS_ONLY")
         self.assertEqual({row["id"] for row in payload["scenario_results"]}, {"CS-REG-016", "CS-REG-017", "CS-REG-018"})
         summaries = payload["component_summaries"]
-        self.assertEqual(summaries["claim_evidence"]["trust_states"], {"unsupported": "draft", "evidence_backed": "evidence_backed", "approved": "approved"})
-        self.assertIn("claim.approved", summaries["audit_ledger"]["event_types"])
+        claim_summary = summaries["claim_evidence"]
+        self.assertEqual(
+            claim_summary["claim_states"],
+            {
+                "unsupported_draft": "draft",
+                "source_supported_draft": "draft",
+                "post_semantic_gate_draft": "draft",
+            },
+        )
+        self.assertEqual(claim_summary["source_support_status"], "source_supported")
+        self.assertEqual(claim_summary["semantic_support_state"], "human_required")
+        self.assertFalse(claim_summary["semantic_support_verified"])
+        self.assertIn("CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED", claim_summary["approval_error_codes"])
+        for authority in (
+            claim_summary["source_supported_authority"],
+            claim_summary["post_approval_attempt_authority"],
+        ):
+            self.assertFalse(authority["can_be_approved"])
+            self.assertFalse(authority["can_publish_shared_truth"])
+            self.assertFalse(authority["can_drive_autonomous_action"])
+        self.assertIn("claim.approval.denied", summaries["audit_ledger"]["event_types"])
         self.assertIn("policy.egress.denied", summaries["audit_ledger"]["event_types"])
         self.assertEqual(summaries["security_policy"]["egress_external_http_calls"], 0)
         self.assertEqual(set(summaries["security_policy"]["sandbox_cases"]), {"sandbox_environment", "sandbox_filesystem", "sandbox_host", "sandbox_shell"})
+        self.assertEqual(payload["human_required"][0]["status"], "HUMAN_REQUIRED")
         for value in payload["negative_evidence"].values():
             self.assertEqual(value, 0)
 
@@ -16483,12 +16522,14 @@ LocalRuntimeStore(state_dir).append_audit(
         payload = json.loads(result.stdout)
         self.assertEqual(payload["scenario_set"], "vs0-detail-surfaces")
         self.assertEqual(payload["summary"]["blocking"], 0)
-        self.assertEqual(payload["summary"]["pass"], 5)
+        self.assertEqual(payload["summary"]["pass"], 4)
         self.assertEqual(payload["summary"]["product_feature_claims"], "PARTIAL_VS0_DETAIL_SURFACES_ONLY")
         self.assertEqual(
             {row["id"] for row in payload["scenario_results"]},
             {"CS-UND-004", "CS-CLAIM-005", "CS-CLAIM-008", "CS-NS-002", "CS-SEC-005"},
         )
+        row_statuses = {row["id"]: row["status"] for row in payload["scenario_results"]}
+        self.assertEqual(row_statuses["CS-CLAIM-005"], "HUMAN_REQUIRED")
         evidence = payload["detail_surface_evidence"]
         self.assertIn("personal / default", evidence["workspace_labels"]["personal"])
         self.assertIn("organization / ops", evidence["workspace_labels"]["organization"])
@@ -16499,20 +16540,46 @@ LocalRuntimeStore(state_dir).append_audit(
         self.assertEqual(evidence["artifact_derived_status"], "ready")
         self.assertTrue(evidence["artifact_original_storage_ref"].startswith("sha256:"))
         self.assertEqual(
-            evidence["trust_states"],
-            {"draft": "draft", "evidence_backed": "evidence_backed", "approved": "approved"},
+            evidence["claim_states"],
+            {
+                "unsupported_draft": "draft",
+                "source_supported_draft": "draft",
+                "post_semantic_gate_draft": "draft",
+            },
         )
-        self.assertTrue(evidence["trust_authority"]["draft"]["can_be_approved"] is False)
-        self.assertTrue(evidence["trust_authority"]["evidence_backed"]["can_be_approved"])
-        self.assertTrue(evidence["trust_authority"]["approved"]["can_publish_shared_truth"])
+        for authority in evidence["claim_authority"].values():
+            self.assertFalse(authority["can_be_approved"])
+            self.assertFalse(authority["can_publish_shared_truth"])
+            self.assertFalse(authority["can_drive_autonomous_action"])
+        support = evidence["source_supported_statement_support"]
+        self.assertEqual(support["status"], "source_supported")
+        self.assertEqual(support["semantic_faithfulness_state"], "human_required")
+        self.assertFalse(support["semantic_support_verified"])
+        self.assertFalse(support["approval_eligible"])
+        self.assertEqual(evidence["semantic_approval_exit_code"], 4)
+        self.assertIn("CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED", evidence["semantic_approval_error_codes"])
+        self.assertEqual(evidence["action_policy"]["decision"], "deny")
+        self.assertEqual(evidence["action_policy"]["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
+        self.assertEqual(evidence["action_policy"]["execution_status"], "blocked_by_claim_authority")
+        self.assertFalse(evidence["action_policy"]["can_execute_now"])
+        self.assertEqual(evidence["action_approval_exit_code"], 8)
+        self.assertEqual(evidence["action_execution_exit_code"], 8)
         self.assertTrue(evidence["evidence_viewer_id"].startswith("viewer_"))
         self.assertEqual(evidence["evidence_viewer_item_count"], 1)
         self.assertIn("alpha-evidence-anchor", evidence["evidence_viewer_first_item"]["derived"]["text_preview"])
         self.assertEqual(
             {example["error_code"] for example in evidence["denial_examples"].values()},
-            {"CS_EGRESS_DENIED", "CS_SANDBOX_ACCESS_DENIED", "CS_CLAIM_EVIDENCE_REQUIRED", "CS_ACTION_POLICY_DENIED"},
+            {
+                "CS_EGRESS_DENIED",
+                "CS_SANDBOX_ACCESS_DENIED",
+                "CS_CLAIM_EVIDENCE_REQUIRED",
+                "CS_CLAIM_SEMANTIC_SUPPORT_REQUIRED",
+                "CS_ACTION_APPROVAL_DENIED",
+                "CS_ACTION_POLICY_DENIED",
+            },
         )
         self.assertTrue(all(example["resolution_path"] for example in evidence["denial_examples"].values()))
+        self.assertEqual(payload["human_required"][0]["status"], "HUMAN_REQUIRED")
         for value in payload["negative_evidence"].values():
             self.assertEqual(value, 0)
 
@@ -16540,7 +16607,19 @@ LocalRuntimeStore(state_dir).append_audit(
         self.assertEqual(evidence["brief_trust_label"], "extractive_fallback")
         self.assertFalse(evidence["brief_presented_as_fact"])
         self.assertTrue(evidence["promoted_claim_id"].startswith("claim_"))
-        self.assertEqual(evidence["promoted_claim_trust_state"], "evidence_backed")
+        self.assertEqual(evidence["promoted_claim_status"], "draft")
+        self.assertEqual(evidence["promoted_claim_trust_state"], "draft")
+        support = evidence["promoted_claim_statement_support"]
+        self.assertEqual(support["status"], "source_supported")
+        self.assertEqual(support["statement_support_state"], "source_supported")
+        self.assertEqual(support["source_support_state"], "passed")
+        self.assertEqual(support["semantic_faithfulness_state"], "human_required")
+        self.assertFalse(support["semantic_support_verified"])
+        self.assertFalse(support["approval_eligible"])
+        authority = evidence["promoted_claim_authority"]
+        self.assertFalse(authority["can_be_approved"])
+        self.assertFalse(authority["can_publish_shared_truth"])
+        self.assertFalse(authority["can_drive_autonomous_action"])
         self.assertEqual(evidence["promoted_claim_source_conversation"]["conversation_id"], evidence["conversation_id"])
         self.assertEqual(evidence["promoted_claim_source_conversation"]["source_artifact_ref"], f"artifact:{evidence['source_artifact_id']}")
         self.assertEqual(evidence["promoted_claim_provenance"]["created_from"], "conversation.promote")
@@ -16558,6 +16637,7 @@ LocalRuntimeStore(state_dir).append_audit(
         self.assertIn("budget", evidence["unsupported_answer_meaningful_question_terms"])
         self.assertEqual(evidence["unsupported_answer_matched_terms"], [])
         self.assertLessEqual(evidence["first_use_duration_ms"], 5000)
+        self.assertEqual(payload["human_required"][0]["status"], "HUMAN_REQUIRED")
         for value in payload["negative_evidence"].values():
             self.assertEqual(value, 0)
 

--- a/tests/scenario/test_trust_foundation_runtime.py
+++ b/tests/scenario/test_trust_foundation_runtime.py
@@ -1,0 +1,810 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import re
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from cornerstone_cli.main import main as cli_main
+from cornerstone_cli.runtime import LocalRuntimeStore
+
+
+SCOPE = {
+    "tenant_id": "tenant-trust",
+    "owner_id": "owner-trust",
+    "namespace_id": "namespace-trust",
+    "workspace_id": "workspace-trust",
+}
+
+
+class TrustFoundationRuntimeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.state_dir = Path(self.temporary.name)
+        self.store = LocalRuntimeStore(self.state_dir)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def ingest(self, text: str, *, source_ref: str = "trust-probe") -> dict:
+        return self.store.ingest_text_artifact(
+            text,
+            dict(SCOPE),
+            source_type="user_paste",
+            source_ref=source_ref,
+        )["artifact"]
+
+    def bundle_for(self, query: str) -> dict:
+        snapshot = self.store.search(query, **SCOPE)["snapshot"]
+        result = self.store.create_evidence_bundle(snapshot["search_snapshot_id"], dict(SCOPE))
+        self.assertNotIn("status", result)
+        return result["bundle"]
+
+    def test_original_store_is_atomic_fresh_and_repairs_corrupt_existing_content(self) -> None:
+        data = b"expected original bytes"
+        corrupt = b"corrupt! original bytes"
+        self.assertEqual(len(data), len(corrupt))
+        artifact = self.store.ingest_artifact_bytes(
+            data,
+            filename="source.txt",
+            source="upload",
+            media_type="text/plain",
+            derived_mode="auto",
+            trust="untrusted",
+            lineage_from=None,
+            **SCOPE,
+        )["artifact"]
+        original_path = self.store.original_dir / artifact["checksum_sha256"]
+        original_stat = original_path.stat()
+        self.assertTrue(self.store.original_available(artifact))
+
+        original_path.write_bytes(corrupt)
+        os.utime(original_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        self.assertFalse(self.store.original_available(artifact))
+
+        repaired = self.store.ingest_artifact_bytes(
+            data,
+            filename="source.txt",
+            source="upload",
+            media_type="text/plain",
+            derived_mode="auto",
+            trust="untrusted",
+            lineage_from=None,
+            **SCOPE,
+        )
+        self.assertTrue(repaired["deduplicated"])
+        self.assertEqual(repaired["audit_event"]["details"]["original_storage_status"], "repaired")
+        self.assertEqual(original_path.read_bytes(), data)
+        self.assertTrue(self.store.original_available(repaired["artifact"]))
+
+    def test_interrupted_atomic_write_creates_no_artifact_audit_or_temporary_file(self) -> None:
+        with patch("cornerstone_cli.archive_integrity.os.replace", side_effect=OSError("interrupted")):
+            with self.assertRaises(OSError):
+                self.store.ingest_text_artifact(
+                    "interrupted archive write",
+                    dict(SCOPE),
+                    source_type="user_paste",
+                    source_ref="interrupted",
+                )
+        self.assertEqual(list(self.store.record_dir.rglob("*.json")), [])
+        self.assertFalse(self.store.audit_path.exists())
+        self.assertEqual(list(self.store.original_dir.glob("*.tmp")), [])
+
+    def test_atomic_repair_replaces_symlink_without_mutating_its_target(self) -> None:
+        data = b"content addressed original"
+        checksum = hashlib.sha256(data).hexdigest()
+        self.store.original_dir.mkdir(parents=True, exist_ok=True)
+        target = self.state_dir / "outside-target"
+        target.write_bytes(b"outside remains unchanged")
+        original_path = self.store.original_dir / checksum
+        original_path.symlink_to(target)
+
+        artifact = self.store.ingest_artifact_bytes(
+            data,
+            filename="source.txt",
+            source="upload",
+            media_type="text/plain",
+            derived_mode="auto",
+            trust="untrusted",
+            lineage_from=None,
+            **SCOPE,
+        )["artifact"]
+        self.assertFalse(original_path.is_symlink())
+        self.assertEqual(original_path.read_bytes(), data)
+        self.assertEqual(target.read_bytes(), b"outside remains unchanged")
+        self.assertTrue(self.store.original_available(artifact))
+
+    def test_artifact_ids_are_full_sha256_with_verified_legacy_compatibility(self) -> None:
+        data = "legacy-compatible artifact"
+        canonical = self.ingest(data)
+        checksum = canonical["checksum_sha256"]
+        self.assertEqual(canonical["artifact_id"], f"art_{checksum}")
+
+        canonical_path = self.store.artifact_path(canonical["artifact_id"], SCOPE)
+        legacy_id = f"art_{checksum[:16]}"
+        legacy = json.loads(canonical_path.read_text())
+        legacy["artifact_id"] = legacy_id
+        legacy_path = self.store.artifact_path(legacy_id, SCOPE)
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(json.dumps(legacy, indent=2, sort_keys=True) + "\n")
+        canonical_path.unlink()
+
+        reused = self.store.ingest_text_artifact(
+            data,
+            dict(SCOPE),
+            source_type="user_paste",
+            source_ref="legacy-retry",
+        )
+        self.assertTrue(reused["deduplicated"])
+        self.assertEqual(reused["artifact"]["artifact_id"], legacy_id)
+        self.assertRegex(reused["artifact"]["derived"]["derived_representation_id"], r"^drv_[0-9a-f]{64}$")
+
+    def test_short_prefix_conflict_does_not_deduplicate_different_content(self) -> None:
+        incoming = b"incoming collision-safe content"
+        checksum = hashlib.sha256(incoming).hexdigest()
+        legacy_id = f"art_{checksum[:16]}"
+        other = b"different stored content"
+        other_checksum = hashlib.sha256(other).hexdigest()
+        conflict = {
+            "schema_version": "cs.artifact.v0",
+            "artifact_id": legacy_id,
+            "checksum_sha256": other_checksum,
+            "content_identity": {"algorithm": "sha256", "value": other_checksum},
+            "original_storage_ref": f"sha256:{other_checksum}",
+            "original_size_bytes": len(other),
+            "media_type": "text/plain",
+            "scope": dict(SCOPE),
+            "derived": {"status": "deferred"},
+        }
+        conflict_path = self.store.artifact_path(legacy_id, SCOPE)
+        conflict_path.parent.mkdir(parents=True, exist_ok=True)
+        conflict_path.write_text(json.dumps(conflict, indent=2, sort_keys=True) + "\n")
+
+        created = self.store.ingest_artifact_bytes(
+            incoming,
+            filename="incoming.txt",
+            source="upload",
+            media_type="text/plain",
+            derived_mode="auto",
+            trust="untrusted",
+            lineage_from=None,
+            **SCOPE,
+        )
+        self.assertFalse(created["deduplicated"])
+        self.assertEqual(created["artifact"]["artifact_id"], f"art_{checksum}")
+        self.assertNotEqual(created["artifact"]["artifact_id"], legacy_id)
+
+    def test_derived_representation_revision_survives_artifact_reprocessing(self) -> None:
+        source_text = "Alice approved the vendor renewal."
+        artifact = self.ingest(source_text)
+        bundle = self.bundle_for("Alice approved vendor renewal")
+        item = bundle["evidence_items"][0]
+        original_representation_id = item["derived_representation_id"]
+
+        replacement = self.store._create_derived_representation(
+            artifact_id=artifact["artifact_id"],
+            artifact_checksum_sha256=artifact["checksum_sha256"],
+            text="Bob rejected the vendor renewal.",
+            redacted=False,
+        )
+        stored_artifact = json.loads(self.store.artifact_path(artifact["artifact_id"], SCOPE).read_text())
+        stored_artifact["derived"] = replacement
+        self.store.artifact_path(artifact["artifact_id"], SCOPE).write_text(
+            json.dumps(stored_artifact, indent=2, sort_keys=True) + "\n"
+        )
+
+        viewer = self.store.view_evidence_bundle(bundle["evidence_bundle_id"], dict(SCOPE))["viewer"]
+        self.assertIn("Alice approved", viewer["viewer_items"][0]["derived"]["text_preview"])
+        self.assertNotIn("Bob rejected", viewer["viewer_items"][0]["derived"]["text_preview"])
+        self.assertEqual(
+            viewer["viewer_items"][0]["derived"]["metadata"]["derived_representation_id"],
+            original_representation_id,
+        )
+
+        chunks = self.store._build_evidence_chunks(
+            bundle["evidence_items"],
+            dict(SCOPE),
+            query="Alice approved",
+            evidence_bundle_id=bundle["evidence_bundle_id"],
+            evidence_revision_sha256=bundle["evidence_revision_sha256"],
+        )["chunks"]
+        citation_ref = f"evidence_chunk:{chunks[0]['evidence_chunk_id']}"
+        citation = self.store._citation_check(
+            output_kind="trust_regression",
+            citation_refs=[citation_ref],
+            scope=dict(SCOPE),
+        )
+        self.assertEqual(citation["status"], "passed")
+        self.assertEqual(citation["resolved_citations"][0]["derived_representation_ref"], item["derived_representation_ref"])
+
+    def test_snapshot_bundle_and_derived_tampering_fail_closed(self) -> None:
+        artifact = self.ingest("Alpha evidence remains immutable.")
+        snapshot = self.store.search("Alpha evidence", **SCOPE)["snapshot"]
+        snapshot_path = self.store.search_snapshot_path(snapshot["search_snapshot_id"])
+        changed_snapshot = json.loads(snapshot_path.read_text())
+        changed_snapshot["results"][0]["snippet"] = "forged snapshot snippet"
+        snapshot_path.write_text(json.dumps(changed_snapshot, indent=2, sort_keys=True) + "\n")
+        denied = self.store.create_evidence_bundle(snapshot["search_snapshot_id"], dict(SCOPE))
+        self.assertEqual(denied["status"], "integrity_failed")
+        self.assertEqual(denied["reason"], "search_snapshot_record_changed")
+
+        clean_snapshot = self.store.search("Alpha evidence", **SCOPE)["snapshot"]
+        bundle = self.store.create_evidence_bundle(clean_snapshot["search_snapshot_id"], dict(SCOPE))["bundle"]
+        chunks = self.store._build_evidence_chunks(
+            bundle["evidence_items"],
+            dict(SCOPE),
+            query="Alpha evidence",
+            evidence_bundle_id=bundle["evidence_bundle_id"],
+            evidence_revision_sha256=bundle["evidence_revision_sha256"],
+        )["chunks"]
+        citation_ref = f"evidence_chunk:{chunks[0]['evidence_chunk_id']}"
+
+        bundle_path = self.store.evidence_bundle_path(bundle["evidence_bundle_id"])
+        changed_bundle = json.loads(bundle_path.read_text())
+        changed_bundle["evidence_items"][0]["snippet"] = "forged bundle snippet"
+        bundle_path.write_text(json.dumps(changed_bundle, indent=2, sort_keys=True) + "\n")
+        bundle_check = self.store._citation_check(
+            output_kind="trust_regression",
+            citation_refs=[citation_ref],
+            scope=dict(SCOPE),
+        )
+        self.assertEqual(bundle_check["status"], "failed")
+        self.assertEqual(bundle_check["evidence_revision_mismatch_count"], 1)
+
+        bundle_path.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n")
+        derived_path = self.store.artifact_dir / bundle["evidence_items"][0]["derived_storage_ref"]
+        original_derived = derived_path.read_bytes()
+        derived_path.write_bytes(b"X" * len(original_derived))
+        derived_check = self.store._citation_check(
+            output_kind="trust_regression",
+            citation_refs=[citation_ref],
+            scope=dict(SCOPE),
+        )
+        self.assertEqual(derived_check["status"], "failed")
+        self.assertEqual(derived_check["derived_representation_mismatch_count"], 1)
+        self.assertTrue(self.store.original_available(artifact))
+
+    def test_evidence_chunks_are_immutable_across_retrieval_queries(self) -> None:
+        self.ingest("Alpha evidence and Gamma evidence share one source.")
+        bundle = self.bundle_for("Alpha Gamma evidence")
+        first = self.store._build_evidence_chunks(
+            bundle["evidence_items"],
+            dict(SCOPE),
+            query="Alpha",
+            evidence_bundle_id=bundle["evidence_bundle_id"],
+            evidence_revision_sha256=bundle["evidence_revision_sha256"],
+        )["chunks"][0]
+        first_path = self.store.evidence_chunk_path(first["evidence_chunk_id"])
+        first_bytes = first_path.read_bytes()
+        second = self.store._build_evidence_chunks(
+            bundle["evidence_items"],
+            dict(SCOPE),
+            query="MissingTerm",
+            evidence_bundle_id=bundle["evidence_bundle_id"],
+            evidence_revision_sha256=bundle["evidence_revision_sha256"],
+        )["chunks"][0]
+        self.assertRegex(first["evidence_chunk_id"], r"^chunk_[0-9a-f]{64}$")
+        self.assertNotEqual(first["evidence_chunk_id"], second["evidence_chunk_id"])
+        self.assertEqual(first_path.read_bytes(), first_bytes)
+
+    def test_view_export_and_effective_reads_require_bound_provenance_and_verified_originals(self) -> None:
+        source_text = "Vendor renewal auto-renewal is August 1."
+        artifact = self.ingest(source_text, source_ref="source-a")
+        bundle = self.bundle_for("Vendor renewal August 1")
+        brief = self.store.create_brief_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            dict(SCOPE),
+        )["brief"]
+        claim = self.store.create_claim_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            source_text,
+            dict(SCOPE),
+        )["claim"]
+        bound_source = bundle["evidence_items"][0]["source"]
+        bound_provenance = bundle["evidence_items"][0]["provenance"]
+
+        rebound = self.store.ingest_text_artifact(
+            source_text,
+            dict(SCOPE),
+            source_type="user_paste",
+            source_ref="source-b",
+        )["artifact"]
+        self.assertEqual(rebound["source"]["ref"], "source-b")
+
+        viewer = self.store.view_evidence_bundle(bundle["evidence_bundle_id"], dict(SCOPE))["viewer"]
+        self.assertEqual(viewer["viewer_items"][0]["original"]["source"], bound_source)
+        self.assertEqual(viewer["viewer_items"][0]["provenance"], bound_provenance)
+        exported = self.store.export_claim_basis(claim["claim_id"], dict(SCOPE))["claim_basis_export"]
+        self.assertEqual(exported["source_artifacts"][0]["source"], bound_source)
+        self.assertEqual(exported["source_artifacts"][0]["provenance"], bound_provenance)
+        self.assertTrue(exported["freshness"]["reproducible_from_archive"])
+
+        original_path = self.store.original_dir / artifact["checksum_sha256"]
+        original_path.write_bytes(b"X" * artifact["original_size_bytes"])
+        denied_view = self.store.view_evidence_bundle(bundle["evidence_bundle_id"], dict(SCOPE))
+        denied_export = self.store.export_claim_basis(claim["claim_id"], dict(SCOPE))
+        self.assertEqual(denied_view["status"], "integrity_failed")
+        self.assertEqual(denied_view["reason"], "evidence_original_missing_or_changed")
+        self.assertEqual(denied_export["status"], "integrity_failed")
+
+        effective_claim = self.store.get_claim(claim["claim_id"])
+        self.assertEqual(effective_claim["evidence_integrity"]["status"], "failed")
+        self.assertEqual(effective_claim["statement_support"]["status"], "integrity_failed")
+        self.assertFalse(effective_claim["authority"]["can_be_approved"])
+        effective_brief = self.store.get_brief(brief["brief_id"])
+        self.assertEqual(effective_brief["status"], "integrity_failed")
+        self.assertEqual(effective_brief["trust_label"], "draft")
+        self.assertFalse(effective_brief["presented_as_fact"])
+
+    def test_chunk_identity_and_span_schema_tampering_fail_closed_without_exception(self) -> None:
+        self.ingest("Alpha evidence has a valid source span.")
+        bundle = self.bundle_for("Alpha evidence")
+        chunk = self.store._build_evidence_chunks(
+            bundle["evidence_items"],
+            dict(SCOPE),
+            query="Alpha evidence",
+            evidence_bundle_id=bundle["evidence_bundle_id"],
+            evidence_revision_sha256=bundle["evidence_revision_sha256"],
+        )["chunks"][0]
+        full_ref = f"evidence_chunk:{chunk['evidence_chunk_id']}"
+        full_path = self.store.evidence_chunk_path(chunk["evidence_chunk_id"])
+        tampered = json.loads(full_path.read_text())
+        tampered["span"]["char_start"] = "oops"
+        full_path.write_text(json.dumps(tampered, indent=2, sort_keys=True) + "\n")
+        full_check = self.store._citation_check(
+            output_kind="trust_regression",
+            citation_refs=[full_ref],
+            scope=dict(SCOPE),
+        )
+        self.assertEqual(full_check["status"], "failed")
+        self.assertEqual(full_check["errors"][0]["code"], "UNRESOLVED_CITATION_REF")
+
+        legacy_id = f"chunk_{'a' * 16}"
+        legacy = dict(chunk)
+        legacy["evidence_chunk_id"] = legacy_id
+        legacy["evidence_refs"] = [
+            f"evidence_chunk:{legacy_id}" if ref.startswith("evidence_chunk:") else ref
+            for ref in legacy["evidence_refs"]
+        ]
+        legacy["span"] = {"char_start": "oops", "char_end": 5}
+        self.store.evidence_chunk_path(legacy_id).write_text(json.dumps(legacy, indent=2, sort_keys=True) + "\n")
+        legacy_check = self.store._citation_check(
+            output_kind="trust_regression",
+            citation_refs=[f"evidence_chunk:{legacy_id}"],
+            scope=dict(SCOPE),
+        )
+        self.assertEqual(legacy_check["status"], "failed")
+        self.assertEqual(legacy_check["errors"][0]["code"], "UNRESOLVED_CITATION_REF")
+
+    def test_artifact_identity_mismatches_and_legacy_revisions_fail_closed_structurally(self) -> None:
+        source_text = "Canonical identity must remain exact."
+        artifact = self.ingest(source_text)
+        artifact_path = self.store.artifact_path(artifact["artifact_id"], SCOPE)
+        changed = json.loads(artifact_path.read_text())
+        changed["original_size_bytes"] += 1
+        artifact_path.write_text(json.dumps(changed, indent=2, sort_keys=True) + "\n")
+        audit_count = len(self.store._all_audit_events())
+        canonical_retry = self.store.ingest_text_artifact(
+            source_text,
+            dict(SCOPE),
+            source_type="user_paste",
+            source_ref="canonical-retry",
+        )
+        self.assertEqual(canonical_retry["status"], "integrity_failed")
+        self.assertEqual(canonical_retry["reason"], "canonical_artifact_identity_mismatch")
+        self.assertEqual(len(self.store._all_audit_events()), audit_count)
+        ingest_output = io.StringIO()
+        with patch("sys.stdout", ingest_output):
+            ingest_exit = cli_main(
+                [
+                    "artifact",
+                    "ingest",
+                    "--text",
+                    source_text,
+                    "--state-dir",
+                    str(self.state_dir),
+                    "--tenant-id",
+                    SCOPE["tenant_id"],
+                    "--owner-id",
+                    SCOPE["owner_id"],
+                    "--namespace-id",
+                    SCOPE["namespace_id"],
+                    "--workspace-id",
+                    SCOPE["workspace_id"],
+                    "--json",
+                ]
+            )
+        self.assertEqual(ingest_exit, 5)
+        self.assertEqual(
+            json.loads(ingest_output.getvalue())["errors"][0]["code"],
+            "CS_ARTIFACT_IDENTITY_INTEGRITY_FAILED",
+        )
+
+        legacy_text = "Legacy Artifact identity must remain exact."
+        legacy_artifact = self.ingest(legacy_text)
+        legacy_checksum = legacy_artifact["checksum_sha256"]
+        canonical_legacy_path = self.store.artifact_path(legacy_artifact["artifact_id"], SCOPE)
+        legacy_id = f"art_{legacy_checksum[:16]}"
+        legacy_record = json.loads(canonical_legacy_path.read_text())
+        legacy_record["artifact_id"] = legacy_id
+        legacy_record["original_size_bytes"] += 1
+        legacy_path = self.store.artifact_path(legacy_id, SCOPE)
+        legacy_path.write_text(json.dumps(legacy_record, indent=2, sort_keys=True) + "\n")
+        canonical_legacy_path.unlink()
+        legacy_retry = self.store.ingest_text_artifact(
+            legacy_text,
+            dict(SCOPE),
+            source_type="user_paste",
+            source_ref="legacy-integrity-retry",
+        )
+        self.assertEqual(legacy_retry["status"], "integrity_failed")
+        self.assertEqual(legacy_retry["reason"], "legacy_artifact_identity_mismatch")
+
+        clean_snapshot = self.store.search("Canonical identity", **SCOPE)["snapshot"]
+        snapshot_path = self.store.search_snapshot_path(clean_snapshot["search_snapshot_id"])
+        legacy_snapshot = json.loads(snapshot_path.read_text())
+        legacy_snapshot.pop("result_revision_sha256")
+        snapshot_path.write_text(json.dumps(legacy_snapshot, indent=2, sort_keys=True) + "\n")
+        denied_snapshot = self.store.read_search_snapshot(
+            clean_snapshot["search_snapshot_id"],
+            dict(SCOPE),
+            reason="legacy_revision_probe",
+        )
+        self.assertEqual(denied_snapshot["status"], "integrity_failed")
+
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            exit_code = cli_main(
+                [
+                    "search",
+                    "snapshot",
+                    "show",
+                    clean_snapshot["search_snapshot_id"],
+                    "--state-dir",
+                    str(self.state_dir),
+                    "--tenant-id",
+                    SCOPE["tenant_id"],
+                    "--owner-id",
+                    SCOPE["owner_id"],
+                    "--namespace-id",
+                    SCOPE["namespace_id"],
+                    "--workspace-id",
+                    SCOPE["workspace_id"],
+                    "--json",
+                ]
+            )
+        self.assertEqual(exit_code, 5)
+        cli_payload = json.loads(output.getvalue())
+        self.assertEqual(cli_payload["errors"][0]["code"], "CS_SEARCH_SNAPSHOT_INTEGRITY_FAILED")
+
+        bundle_source = self.ingest("Legacy Bundle revisions are retired fail-closed.")
+        self.assertTrue(bundle_source["artifact_id"].startswith("art_"))
+        bundle = self.bundle_for("Legacy Bundle revisions")
+        bundle_path = self.store.evidence_bundle_path(bundle["evidence_bundle_id"])
+        legacy_bundle = json.loads(bundle_path.read_text())
+        legacy_bundle.pop("evidence_revision_sha256")
+        bundle_path.write_text(json.dumps(legacy_bundle, indent=2, sort_keys=True) + "\n")
+        denied_bundle = self.store.show_evidence_bundle(bundle["evidence_bundle_id"], dict(SCOPE))
+        self.assertEqual(denied_bundle["status"], "integrity_failed")
+        self.assertEqual(denied_bundle["reason"], "evidence_bundle_record_changed")
+
+    def test_semantic_inversions_remain_source_supported_drafts_and_cannot_be_approved(self) -> None:
+        self.ingest(
+            "Alice sold the asset to Bob. Flooding caused equipment failure. "
+            "Alice scored greater than Bob. Revenue rose from 10 to 20. "
+            "The vendor may terminate the agreement. Payment occurs before delivery. "
+            "Alice did not approve the plan, and Bob did sign the plan."
+        )
+        bundle = self.bundle_for("Alice Bob asset flooding failure revenue vendor payment delivery plan")
+        inverted = [
+            "Bob sold the asset to Alice.",
+            "Equipment failure caused flooding.",
+            "Bob scored greater than Alice.",
+            "Revenue fell from 20 to 10.",
+            "The vendor must terminate the agreement.",
+            "Payment occurs after delivery.",
+            "Alice did approve the plan, and Bob did not sign the plan.",
+        ]
+        for statement in inverted:
+            with self.subTest(statement=statement):
+                claim = self.store.create_claim_from_evidence_bundle(
+                    bundle["evidence_bundle_id"], statement, dict(SCOPE)
+                )["claim"]
+                self.assertEqual(claim["status"], "draft")
+                self.assertEqual(claim["trust_state"], "draft")
+                self.assertEqual(claim["statement_support"]["status"], "source_supported")
+                self.assertFalse(claim["statement_support"]["semantic_support_verified"])
+                self.assertFalse(claim["statement_support"]["approval_eligible"])
+                self.assertFalse(claim["authority"]["can_be_approved"])
+                approval = self.store.approve_claim(claim["claim_id"], dict(SCOPE))
+                self.assertEqual(approval["status"], "semantic_support_required")
+                self.assertEqual(approval["claim"]["trust_state"], "draft")
+                self.assertFalse(approval["claim"]["authority"]["can_publish_shared_truth"])
+
+    def test_legacy_claim_authority_is_effectively_downgraded_without_mutating_history(self) -> None:
+        legacy = {
+            "schema_version": "cs.claim.v0",
+            "claim_id": "claim_legacy_authority",
+            "status": "approved",
+            "trust_state": "approved",
+            "statement": "A lexical Claim was previously approved.",
+            "scope": dict(SCOPE),
+            "statement_support": {
+                "status": "passed",
+                "statement_support_state": "deterministic_anchor_passed",
+                "semantic_faithfulness_state": "human_required",
+                "semantic_support_verified": True,
+                "approval_eligible": True,
+            },
+            "authority": {
+                "can_be_approved": True,
+                "can_publish_shared_truth": True,
+                "can_drive_autonomous_action": True,
+            },
+            "evidence_bundle": {"artifact_refs": ["artifact:legacy"]},
+        }
+        path = self.store.claim_path(legacy["claim_id"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(legacy, indent=2, sort_keys=True) + "\n")
+
+        effective = self.store.get_claim(legacy["claim_id"])
+        self.assertEqual(effective["status"], "draft")
+        self.assertEqual(effective["trust_state"], "draft")
+        self.assertEqual(effective["statement_support"]["status"], "not_verified")
+        self.assertFalse(effective["statement_support"]["semantic_support_verified"])
+        self.assertFalse(effective["authority"]["can_publish_shared_truth"])
+        self.assertFalse(effective["authority"]["can_drive_autonomous_action"])
+        self.assertEqual(effective["effective_authority_migration"]["recorded_status"], "approved")
+        self.assertEqual(json.loads(path.read_text())["status"], "approved")
+
+    def test_brief_and_claim_payload_identity_are_revalidated_on_read(self) -> None:
+        self.ingest("Acme renewal is due on July 31.")
+        bundle = self.bundle_for("Acme renewal")
+
+        brief = self.store.create_brief_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            dict(SCOPE),
+        )["brief"]
+        brief_path = self.store.brief_path(brief["brief_id"])
+        forged_brief = json.loads(brief_path.read_text())
+        forged_brief["trust_label"] = "evidence_backed"
+        forged_brief["status"] = "evidence_backed"
+        forged_brief["presented_as_fact"] = True
+        forged_brief["key_points"] = ["Forged conclusion with no citation."]
+        brief_path.write_text(json.dumps(forged_brief, indent=2, sort_keys=True) + "\n")
+
+        effective_brief = self.store.get_brief(brief["brief_id"])
+        self.assertEqual(effective_brief["status"], "integrity_failed")
+        self.assertEqual(effective_brief["trust_label"], "draft")
+        self.assertFalse(effective_brief["presented_as_fact"])
+        self.assertEqual(effective_brief["evidence_integrity"]["reason"], "brief_record_changed")
+
+        claim = self.store.create_claim_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            "Acme renewal is due on July 31.",
+            dict(SCOPE),
+        )["claim"]
+        claim_path = self.store.claim_path(claim["claim_id"])
+        forged_claim = json.loads(claim_path.read_text())
+        forged_claim["statement"] = "Acme renewal is not due on July 31."
+        claim_path.write_text(json.dumps(forged_claim, indent=2, sort_keys=True) + "\n")
+
+        effective_claim = self.store.get_claim(claim["claim_id"])
+        self.assertEqual(effective_claim["statement_support"]["status"], "integrity_failed")
+        self.assertFalse(effective_claim["authority"]["can_be_approved"])
+        self.assertEqual(effective_claim["evidence_integrity"]["reason"], "claim_record_changed")
+
+    def test_evidence_backed_brief_requires_current_immutable_citations(self) -> None:
+        self.ingest("Acme renewal is due on July 31.")
+        bundle = self.bundle_for("Acme renewal")
+
+        def generated(*_: object, **kwargs: object) -> dict:
+            match = re.search(r"evidence_chunk:[a-zA-Z0-9_-]+", str(kwargs.get("prompt") or ""))
+            self.assertIsNotNone(match)
+            return {
+                "title": "Acme renewal",
+                "key_points": [
+                    {
+                        "statement": "Acme renewal is due on July 31.",
+                        "citation_refs": [match.group(0)],
+                    }
+                ],
+                "uncertainty": [],
+                "recommended_next_steps": [],
+                "contradictions": [],
+            }
+
+        with patch("cornerstone_cli.runtime._ollama_embedding", return_value=[1.0, 0.0]), patch(
+            "cornerstone_cli.runtime._ollama_generate_json",
+            side_effect=generated,
+        ):
+            brief = self.store.create_brief_from_evidence_bundle(
+                bundle["evidence_bundle_id"],
+                dict(SCOPE),
+                model_provider="ollama",
+            )["brief"]
+
+        self.assertEqual(self.store.get_brief(brief["brief_id"])["trust_label"], "evidence_backed")
+        chunk_id = brief["citation_refs"][0].split(":", 1)[1]
+        self.store.evidence_chunk_path(chunk_id).unlink()
+        effective = self.store.get_brief(brief["brief_id"])
+        self.assertEqual(effective["status"], "integrity_failed")
+        self.assertEqual(effective["trust_label"], "draft")
+        self.assertFalse(effective["presented_as_fact"])
+        self.assertIn("UNRESOLVED_CITATION_REF", effective["evidence_integrity"]["reason"])
+
+    def test_artifact_read_rejects_cross_identity_substitution(self) -> None:
+        first = self.ingest("Artifact A content", source_ref="artifact-a")
+        second = self.ingest("Artifact B replacement content", source_ref="artifact-b")
+        first_path = self.store.artifact_path(first["artifact_id"], SCOPE)
+        substituted = json.loads(first_path.read_text())
+        for key in (
+            "checksum_sha256",
+            "content_identity",
+            "original_storage_ref",
+            "original_size_bytes",
+        ):
+            substituted[key] = second[key]
+        first_path.write_text(json.dumps(substituted, indent=2, sort_keys=True) + "\n")
+
+        shown = self.store.read_product_record(
+            "artifact",
+            first["artifact_id"],
+            dict(SCOPE),
+            reason="identity-substitution-probe",
+        )
+        downloaded = self.store.read_artifact_original(
+            first["artifact_id"],
+            dict(SCOPE),
+            reason="identity-substitution-probe",
+        )
+        self.assertEqual(shown["status"], "integrity_failed")
+        self.assertEqual(downloaded["status"], "integrity_failed")
+        self.assertEqual(shown["reason"], "canonical_artifact_checksum_mismatch")
+
+    def test_full_record_identity_and_malformed_active_records_fail_structurally(self) -> None:
+        self.ingest("The renewal owner is Mina.")
+        snapshot = self.store.search("renewal owner", **SCOPE)["snapshot"]
+        snapshot_path = self.store.search_snapshot_path(snapshot["search_snapshot_id"])
+        tampered_snapshot = json.loads(snapshot_path.read_text())
+        tampered_snapshot["query"] = "forged display query"
+        snapshot_path.write_text(json.dumps(tampered_snapshot, indent=2, sort_keys=True) + "\n")
+        snapshot_read = self.store.read_search_snapshot(
+            snapshot["search_snapshot_id"],
+            dict(SCOPE),
+            reason="full-record-probe",
+        )
+        self.assertEqual(snapshot_read["status"], "integrity_failed")
+        self.assertEqual(snapshot_read["reason"], "search_snapshot_record_changed")
+
+        fresh_snapshot = self.store.search("renewal owner Mina", **SCOPE)["snapshot"]
+        bundle = self.store.create_evidence_bundle(fresh_snapshot["search_snapshot_id"], dict(SCOPE))["bundle"]
+        bundle_path = self.store.evidence_bundle_path(bundle["evidence_bundle_id"])
+        tampered_bundle = json.loads(bundle_path.read_text())
+        tampered_bundle["result_snapshot"]["query"] = "forged embedded query"
+        bundle_path.write_text(json.dumps(tampered_bundle, indent=2, sort_keys=True) + "\n")
+        bundle_read = self.store.show_evidence_bundle(bundle["evidence_bundle_id"], dict(SCOPE))
+        self.assertEqual(bundle_read["status"], "integrity_failed")
+        self.assertEqual(bundle_read["reason"], "evidence_bundle_record_changed")
+
+        malformed = self.store.create_unsupported_claim("Malformed record probe", dict(SCOPE))["claim"]
+        self.store.claim_path(malformed["claim_id"]).write_text("{not-json")
+        claim_read = self.store.read_product_record(
+            "claim",
+            malformed["claim_id"],
+            dict(SCOPE),
+            reason="malformed-record-probe",
+        )
+        self.assertEqual(claim_read["status"], "integrity_failed")
+        self.assertEqual(claim_read["reason"], "claim_record_unreadable_or_changed")
+
+        substituted = self.store.create_unsupported_claim(
+            "Substituted record identity probe",
+            dict(SCOPE),
+        )["claim"]
+        substituted_path = self.store.claim_path(substituted["claim_id"])
+        substituted_record = json.loads(substituted_path.read_text())
+        substituted_record["claim_id"] = f"claim_{'f' * 16}"
+        substituted_path.write_text(json.dumps(substituted_record, indent=2, sort_keys=True) + "\n")
+        substituted_read = self.store.read_product_record(
+            "claim",
+            substituted["claim_id"],
+            dict(SCOPE),
+            reason="substituted-record-probe",
+        )
+        self.assertEqual(substituted_read["status"], "integrity_failed")
+        self.assertEqual(substituted_read["reason"], "claim_record_unreadable_or_changed")
+
+        memory_id = f"memory_{'a' * 16}"
+        memory_path = self.store.memory_path(memory_id)
+        memory_path.parent.mkdir(parents=True, exist_ok=True)
+        memory_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "cs.memory.v0",
+                    "memory_id": f"memory_{'b' * 16}",
+                    "scope": dict(SCOPE),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        memory_read = self.store.read_product_record(
+            "memory",
+            memory_id,
+            dict(SCOPE),
+            reason="substituted-memory-probe",
+        )
+        self.assertEqual(memory_read["status"], "integrity_failed")
+        self.assertEqual(memory_read["reason"], "memory_record_unreadable_or_changed")
+
+    def test_concurrent_same_content_ingest_preserves_both_observations(self) -> None:
+        def ingest(source_ref: str) -> dict:
+            return self.store.ingest_text_artifact(
+                "One immutable source observed concurrently.",
+                dict(SCOPE),
+                source_type="user_paste",
+                source_ref=source_ref,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(ingest, ["source-a", "source-b"]))
+
+        self.assertEqual(sorted(result["deduplicated"] for result in results), [False, True])
+        artifact_id = results[0]["artifact"]["artifact_id"]
+        stored = self.store.get_artifact(artifact_id, dict(SCOPE))
+        observed_refs = {
+            str(source.get("ref"))
+            for source in stored.get("source_history", [])
+            if isinstance(source, dict)
+        }
+        self.assertEqual(observed_refs, {"source-a", "source-b"})
+        events = self.store._all_audit_events()
+        self.assertEqual(sum(event["event_type"] == "artifact.ingested" for event in events), 1)
+        self.assertEqual(sum(event["event_type"] == "artifact.deduplicated" for event in events), 1)
+
+    def test_draft_claim_cannot_approve_or_execute_action_before_replay(self) -> None:
+        self.ingest("The renewal needs an internal status update.")
+        bundle = self.bundle_for("renewal internal status update")
+        claim = self.store.create_claim_from_evidence_bundle(
+            bundle["evidence_bundle_id"],
+            "The renewal needs an internal status update.",
+            dict(SCOPE),
+        )["claim"]
+        mission = self.store.create_mission_contract(
+            "Track the renewal",
+            dict(SCOPE),
+            claim_id=claim["claim_id"],
+        )["mission"]
+        self.store.activate_mission(mission["mission_id"], dict(SCOPE), mode="autopilot")
+        action = self.store.propose_action(
+            mission["mission_id"],
+            claim["claim_id"],
+            "internal_status_update",
+            "low",
+            dict(SCOPE),
+            goal="Record renewal status",
+        )["action_card"]
+        self.assertEqual(action["policy_decision"]["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
+        self.assertFalse(action["execution"]["can_execute_now"])
+        self.assertEqual(action["execution"]["status"], "blocked_by_claim_authority")
+
+        approval = self.store.approve_action(action["action_id"], dict(SCOPE), approver=SCOPE["owner_id"])
+        self.assertEqual(approval["status"], "policy_denied")
+        self.assertEqual(approval["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
+        execution = self.store.execute_action(action["action_id"], dict(SCOPE))
+        self.assertEqual(execution["status"], "policy_denied")
+        self.assertEqual(execution["reason_code"], "CS_ACTION_CLAIM_AUTHORITY_REQUIRED")
+        self.assertFalse(self.store.workflow_run_dir.exists())
+        self.assertFalse(self.store.action_result_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- keep lexical Claim matches as source support only; semantic review and owner approval remain separate, fail-closed gates
- bind Artifacts, Derived Representations, Search Snapshots, Evidence Bundles, chunks, citations, Briefs, and Claims to immutable identities and current revisions
- make original storage atomic, freshly verified, collision-safe, and concurrency-safe
- remove duplicate Home Ask search work and bind pagination to the exact raw-query digest
- improve Claim and blocked-Action UI language, full Artifact reference wrapping, scoped page loading, and the help glyph
- expand active-spine CI and current-source browser evidence validation

## Verification

- 57 product UI route tests
- 16 active-spine CLI tests, including runtime acceptance quickstart
- 5 VS5 citation-integrity tests
- 19 trust-foundation tests
- 47/47 browser pages captured and manifest-validated across desktop and mobile
- compile, SoT, 206-row scenario matrix, design-system, workflow YAML, and diff checks pass

## Proof boundary

This closes structural trust gaps only. VS4-H01 remains rejected/open; real Ollama Plane 2 quality, human semantic review, and external-user value remain NOT_VERIFIED.